### PR TITLE
Log limiting messages on trace level

### DIFF
--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -59,10 +59,10 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         if (ClientQuotaType.PRODUCE.equals(quotaType) && currentStorageUsage > storageQuotaSoft && currentStorageUsage < storageQuotaHard) {
             double minThrottle = quotaMap.getOrDefault(quotaType, Quota.upperBound(Double.MAX_VALUE)).bound();
             double limit = minThrottle * (1.0 - (1.0 * (currentStorageUsage - storageQuotaSoft) / (storageQuotaHard - storageQuotaSoft)));
-            log.debug("Throttling producer rate because disk is beyond soft limit. Used: {}. Quota: {}", storageUsed, limit);
+            log.trace("Throttling producer rate because disk is beyond soft limit. Used: {}. Quota: {}", storageUsed, limit);
             return limit;
         } else if (ClientQuotaType.PRODUCE.equals(quotaType) && currentStorageUsage >= storageQuotaHard) {
-            log.debug("Limiting producer rate because disk is full. Used: {}. Limit: {}", storageUsed, storageQuotaHard);
+            log.trace("Limiting producer rate because disk is full. Used: {}. Limit: {}", storageUsed, storageQuotaHard);
             return 1.0;
         }
         return quotaMap.getOrDefault(quotaType, Quota.upperBound(Double.MAX_VALUE)).bound();

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -74,15 +74,20 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     /**
      * Put a small delay between logging
      */
-    private void maybeLog(AtomicLong latLoggedMessageTimeMs, String format, Object... args) {
-        latLoggedMessageTimeMs.getAndUpdate(current -> {
-            long now = System.currentTimeMillis();
+    private void maybeLog(AtomicLong lastLoggedMessageTimeMs, String format, Object... args) {
+        long now = System.currentTimeMillis();
+        final boolean[] shouldLog = {true};
+        lastLoggedMessageTimeMs.getAndUpdate(current -> {
             if (now - current >= LOGGING_DELAY_MS) {
-                log.debug(format, args);
+                shouldLog[0] = true;
                 return now;
             }
+            shouldLog[0] = false;
             return current;
         });
+        if (shouldLog[0]) {
+            log.debug(format, args);
+        }
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -75,9 +75,10 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
      * Put a small delay between logging
      */
     private void maybeLog(AtomicLong latLoggedMessageTimeMs, String format, Object... args) {
-        if (System.currentTimeMillis() - latLoggedMessageTimeMs.get() >= LOGGING_DELAY_MS) {
+        long now = System.currentTimeMillis();
+        if (now - latLoggedMessageTimeMs.get() >= LOGGING_DELAY_MS) {
             log.debug(format, args);
-            latLoggedMessageTimeMs.set(System.currentTimeMillis());
+            latLoggedMessageTimeMs.set(now);
         }
     }
 

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -75,18 +75,20 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
      * Put a small delay between logging
      */
     private void maybeLog(AtomicLong lastLoggedMessageTimeMs, String format, Object... args) {
-        long now = System.currentTimeMillis();
-        final boolean[] shouldLog = {true};
-        lastLoggedMessageTimeMs.getAndUpdate(current -> {
-            if (now - current >= LOGGING_DELAY_MS) {
-                shouldLog[0] = true;
-                return now;
+        if (log.isDebugEnabled()) {
+            long now = System.currentTimeMillis();
+            final boolean[] shouldLog = {true};
+            lastLoggedMessageTimeMs.getAndUpdate(current -> {
+                if (now - current >= LOGGING_DELAY_MS) {
+                    shouldLog[0] = true;
+                    return now;
+                }
+                shouldLog[0] = false;
+                return current;
+            });
+            if (shouldLog[0]) {
+                log.debug(format, args);
             }
-            shouldLog[0] = false;
-            return current;
-        });
-        if (shouldLog[0]) {
-            log.debug(format, args);
         }
     }
 

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -75,11 +75,14 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
      * Put a small delay between logging
      */
     private void maybeLog(AtomicLong latLoggedMessageTimeMs, String format, Object... args) {
-        long now = System.currentTimeMillis();
-        if (now - latLoggedMessageTimeMs.get() >= LOGGING_DELAY_MS) {
-            log.debug(format, args);
-            latLoggedMessageTimeMs.set(now);
-        }
+        latLoggedMessageTimeMs.getAndUpdate(current -> {
+            long now = System.currentTimeMillis();
+            if (now - current >= LOGGING_DELAY_MS) {
+                log.debug(format, args);
+                return now;
+            }
+            return current;
+        });
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Each incoming message does fire the `quotaLimit` check. If the soft or hard limit is hit, the debug message is logged. And that can be way too verbose. Limiting logging to one message per second should make the logs at least more readable.
The check is performed for the soft and the hard limit separately, so no message should be missed when the soft limit is exceeded to the hard one.