### PR TITLE
Update Kafka dependency to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,8 @@
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
         <kafka.version>3.0.0</kafka.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <junit.version>5.7.2</junit.version>
 
         <!-- property to skip surefire tests during failsafe execution -->
@@ -120,13 +122,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.2.0</version>
+            <version>${yammer-metrics.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>3.0.0</kafka.version>
         <junit.version>5.7.2</junit.version>
 
         <!-- property to skip surefire tests during failsafe execution -->


### PR DESCRIPTION
This PR updates the Kafka dependency to Kafka 3.0.0. It also changes the dependencies for metrics and SLF4J to use variables in the `pom.xml` (but the actual version did not changed as it is still the same in Kafka 3.0).