### PR TITLE
Fix #11: Factor out StorageChecker

### DIFF
--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -4,16 +4,11 @@
  */
 package io.strimzi.kafka.quotas;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -21,7 +16,6 @@ import java.util.stream.Collectors;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.MetricName;
-
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.metrics.Quota;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -40,16 +34,16 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
 
     private volatile Map<ClientQuotaType, Quota> quotaMap = new HashMap<>();
     private final AtomicLong storageUsed = new AtomicLong(0);
-    private volatile List<Path> logDirs;
     private volatile long storageQuotaSoft = Long.MAX_VALUE;
     private volatile long storageQuotaHard = Long.MAX_VALUE;
     private volatile int storageCheckInterval = Integer.MAX_VALUE;
     private volatile List<String> excludedPrincipalNameList = List.of();
     private final AtomicBoolean resetQuota = new AtomicBoolean(false);
-    final StorageChecker storageChecker = new StorageChecker();
+    private final StorageChecker storageChecker = new StorageChecker();
     private final static long LOGGING_DELAY_MS = 1000;
     private AtomicLong lastLoggedMessageSoftTimeMs = new AtomicLong(0);
     private AtomicLong lastLoggedMessageHardTimeMs = new AtomicLong(0);
+    private final String scope = "io.strimzi.kafka.quotas.StaticQuotaCallback";
 
     @Override
     public Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId) {
@@ -139,105 +133,44 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         quotaMap = config.getQuotaMap();
         storageQuotaSoft = config.getSoftStorageQuota();
         storageQuotaHard = config.getHardStorageQuota();
-        storageCheckInterval = config.getStorageCheckInterval();
         excludedPrincipalNameList = config.getExcludedPrincipalNameList();
-        logDirs = Arrays.stream(config.getLogDirs().split(",")).map(Paths::get).collect(Collectors.toList());
+
+        List<Path> logDirs = config.getLogDirs().stream().map(Paths::get).collect(Collectors.toList());
+        storageChecker.configure(config.getStorageCheckInterval(),
+                logDirs,
+                this::updateUsedStorage);
 
         log.info("Configured quota callback with {}. Storage quota (soft, hard): ({}, {}). Storage check interval: {}", quotaMap, storageQuotaSoft, storageQuotaHard, storageCheckInterval);
         if (!excludedPrincipalNameList.isEmpty()) {
             log.info("Excluded principals {}", excludedPrincipalNameList);
         }
+
+        createCustomMetrics();
     }
 
-    class StorageChecker implements Runnable {
-        private final Thread storageCheckerThread = new Thread(this, "storage-quota-checker");
-        private AtomicBoolean running = new AtomicBoolean(false);
-        private String scope = "io.strimzi.kafka.quotas.StaticQuotaCallback";
-
-        private void createCustomMetrics() {
-
-            Metrics.newGauge(metricName("TotalStorageUsedBytes"), new Gauge<Long>() {
-                public Long value() {
-                    return storageUsed.get();
-                }
-            });
-            Metrics.newGauge(metricName("SoftLimitBytes"), new Gauge<Long>() {
-                public Long value() {
-                    return storageQuotaSoft;
-                }
-            });
+    private void updateUsedStorage(Long newValue) {
+        var oldValue = storageUsed.getAndSet(newValue);
+        if (oldValue != newValue) {
+            resetQuota.set(true);
         }
+    }
 
-        private MetricName metricName(String name) {
+    private MetricName metricName(String name) {
+        String mBeanName = "io.strimzi.kafka.quotas:type=StorageChecker,name=" + name + "";
+        return new MetricName("io.strimzi.kafka.quotas", "StorageChecker", name, this.scope, mBeanName);
+    }
 
-            String mBeanName = "io.strimzi.kafka.quotas:type=StorageChecker,name=" + name + "";
-            return new MetricName("io.strimzi.kafka.quotas", "StorageChecker", name, this.scope, mBeanName);
-        }
+    private void createCustomMetrics() {
 
-        void startIfNecessary() {
-            if (running.compareAndSet(false, true)) {
-                createCustomMetrics();
-                storageCheckerThread.setDaemon(true);
-                storageCheckerThread.start();
+        Metrics.newGauge(metricName("TotalStorageUsedBytes"), new Gauge<Long>() {
+            public Long value() {
+                return storageUsed.get();
             }
-        }
-
-        void stop() throws InterruptedException {
-            running.set(false);
-            storageCheckerThread.interrupt();
-            storageCheckerThread.join();
-        }
-
-        @Override
-        public void run() {
-            if (StaticQuotaCallback.this.logDirs != null
-                    && StaticQuotaCallback.this.storageQuotaSoft > 0
-                    && StaticQuotaCallback.this.storageQuotaHard > 0
-                    && StaticQuotaCallback.this.storageCheckInterval > 0) {
-                try {
-                    log.info("Quota Storage Checker is now starting");
-                    while (running.get()) {
-                        try {
-                            long diskUsage = checkDiskUsage();
-                            long previousUsage = StaticQuotaCallback.this.storageUsed.getAndSet(diskUsage);
-                            if (diskUsage != previousUsage) {
-                                StaticQuotaCallback.this.resetQuota.set(true);
-                            }
-                            log.debug("Storage usage checked: {}", StaticQuotaCallback.this.storageUsed.get());
-                            Thread.sleep(TimeUnit.SECONDS.toMillis(StaticQuotaCallback.this.storageCheckInterval));
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            break;
-                        } catch (Exception e) {
-                            log.warn("Exception in storage checker thread", e);
-                        }
-                    }
-                } finally {
-                    log.info("Quota Storage Checker is now finishing");
-                }
+        });
+        Metrics.newGauge(metricName("SoftLimitBytes"), new Gauge<Long>() {
+            public Long value() {
+                return storageQuotaSoft;
             }
-        }
-
-        long checkDiskUsage() {
-            return logDirs.stream()
-                .filter(Files::exists)
-                .map(path -> apply(() -> Files.getFileStore(path)))
-                .distinct()
-                .mapToLong(store -> apply(() -> store.getTotalSpace() - store.getUsableSpace()))
-                .sum();
-        }
-    }
-
-    static <T> T apply(IOSupplier<T> supplier) {
-        try {
-            return supplier.get();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    @FunctionalInterface
-    interface IOSupplier<T> {
-        T get() throws IOException;
+        });
     }
 }

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Type.DOUBLE;
+import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 
@@ -45,7 +46,7 @@ public class StaticQuotaConfig extends AbstractConfig {
                         .define(EXCLUDED_PRINCIPAL_NAME_LIST_PROP, LIST, List.of(), MEDIUM, "List of principals that are excluded from the quota")
                         .define(STORAGE_QUOTA_SOFT_PROP, LONG, Long.MAX_VALUE, HIGH, "Hard limit for amount of storage allowed (in bytes)")
                         .define(STORAGE_QUOTA_HARD_PROP, LONG, Long.MAX_VALUE, HIGH, "Soft limit for amount of storage allowed (in bytes)")
-                        .define(STORAGE_CHECK_INTERVAL_PROP, LONG, 0, MEDIUM, "Interval between storage check runs (default of 0 means disabled")
+                        .define(STORAGE_CHECK_INTERVAL_PROP, INT, 0, MEDIUM, "Interval between storage check runs (in seconds, default of 0 means disabled")
                         .define(LOG_DIRS_PROP, LIST, List.of(), HIGH, "Broker log directories"),
                 props,
                 doLog);
@@ -72,8 +73,8 @@ public class StaticQuotaConfig extends AbstractConfig {
         return getLong(STORAGE_QUOTA_SOFT_PROP);
     }
 
-    long getStorageCheckInterval() {
-        return getLong(STORAGE_CHECK_INTERVAL_PROP);
+    int getStorageCheckInterval() {
+        return getInt(STORAGE_CHECK_INTERVAL_PROP);
     }
 
     List<String> getLogDirs() {

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -16,11 +16,12 @@ import java.util.Map;
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Type.DOUBLE;
-import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
-import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 
+/**
+ * Configuration for the static quota plugin.
+ */
 public class StaticQuotaConfig extends AbstractConfig {
     static final String PRODUCE_QUOTA_PROP = "client.quota.callback.static.produce";
     static final String FETCH_QUOTA_PROP = "client.quota.callback.static.fetch";
@@ -31,6 +32,11 @@ public class StaticQuotaConfig extends AbstractConfig {
     static final String STORAGE_CHECK_INTERVAL_PROP = "client.quota.callback.static.storage.check-interval";
     static final String LOG_DIRS_PROP = "log.dirs";
 
+    /**
+     * Construct a configuration for the static quota plugin.
+     * @param props the configuration properties
+     * @param doLog whether the configurations should be logged
+     */
     public StaticQuotaConfig(Map<String, ?> props, boolean doLog) {
         super(new ConfigDef()
                         .define(PRODUCE_QUOTA_PROP, DOUBLE, Double.MAX_VALUE, HIGH, "Produce bandwidth rate quota (in bytes)")
@@ -39,8 +45,8 @@ public class StaticQuotaConfig extends AbstractConfig {
                         .define(EXCLUDED_PRINCIPAL_NAME_LIST_PROP, LIST, List.of(), MEDIUM, "List of principals that are excluded from the quota")
                         .define(STORAGE_QUOTA_SOFT_PROP, LONG, Long.MAX_VALUE, HIGH, "Hard limit for amount of storage allowed (in bytes)")
                         .define(STORAGE_QUOTA_HARD_PROP, LONG, Long.MAX_VALUE, HIGH, "Soft limit for amount of storage allowed (in bytes)")
-                        .define(STORAGE_CHECK_INTERVAL_PROP, INT, 0, MEDIUM, "Interval between storage check runs (default of 0 means disabled)")
-                        .define(LOG_DIRS_PROP, STRING, "/tmp/kafka-logs", HIGH, "Broker log directory"),
+                        .define(STORAGE_CHECK_INTERVAL_PROP, LONG, 0, MEDIUM, "Interval between storage check runs (default of 0 means disabled")
+                        .define(LOG_DIRS_PROP, LIST, List.of(), HIGH, "Broker log directories"),
                 props,
                 doLog);
     }
@@ -66,12 +72,12 @@ public class StaticQuotaConfig extends AbstractConfig {
         return getLong(STORAGE_QUOTA_SOFT_PROP);
     }
 
-    int getStorageCheckInterval() {
-        return getInt(STORAGE_CHECK_INTERVAL_PROP);
+    long getStorageCheckInterval() {
+        return getLong(STORAGE_CHECK_INTERVAL_PROP);
     }
 
-    String getLogDirs() {
-        return getString(LOG_DIRS_PROP);
+    List<String> getLogDirs() {
+        return getList(LOG_DIRS_PROP);
     }
 
     List<String> getExcludedPrincipalNameList() {

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020, Red Hat Inc.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.quotas;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * Periodically reports the total storage used by one or more filesystems.
+ */
+public class StorageChecker implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(StorageChecker.class);
+
+    private final Thread storageCheckerThread = new Thread(this, "storage-quota-checker");
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicLong storageUsed = new AtomicLong(0);
+
+    private volatile long storageCheckInterval;
+    private volatile List<Path> logDirs;
+    private volatile Consumer<Long> consumer;
+
+    void configure(long storageCheckInterval, List<Path> logDirs, Consumer<Long> consumer) {
+        this.storageCheckInterval = storageCheckInterval;
+        this.logDirs = logDirs;
+        this.consumer = consumer;
+    }
+
+    void startIfNecessary() {
+        if (running.compareAndSet(false, true) && storageCheckInterval > 0) {
+            storageCheckerThread.setDaemon(true);
+            storageCheckerThread.start();
+        }
+    }
+
+    void stop() throws InterruptedException {
+        if (running.compareAndSet(true, false)) {
+            storageCheckerThread.interrupt();
+            storageCheckerThread.join();
+        }
+    }
+
+    @Override
+    public void run() {
+        if (logDirs != null && !logDirs.isEmpty()) {
+            try {
+                log.info("Quota Storage Checker is now starting");
+                while (running.get()) {
+                    try {
+                        long diskUsage = checkDiskUsage();
+                        long previousUsage = storageUsed.getAndSet(diskUsage);
+                        if (diskUsage != previousUsage) {
+                            consumer.accept(diskUsage);
+                        }
+                        log.debug("Storage usage checked: {}", storageUsed.get());
+                        Thread.sleep(TimeUnit.SECONDS.toMillis(storageCheckInterval));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    } catch (Exception e) {
+                        log.warn("Exception in storage checker thread", e);
+                    }
+                }
+            } finally {
+                log.info("Quota Storage Checker is now finishing");
+            }
+        }
+    }
+
+    long checkDiskUsage() {
+        return logDirs.stream()
+                .filter(Files::exists)
+                .map(path -> apply(() -> Files.getFileStore(path)))
+                .distinct()
+                .mapToLong(store -> apply(() -> store.getTotalSpace() - store.getUsableSpace()))
+                .sum();
+    }
+
+    static <T> T apply(IOSupplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @FunctionalInterface
+    interface IOSupplier<T> {
+        T get() throws IOException;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -12,7 +12,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -27,18 +26,18 @@ public class StorageChecker implements Runnable {
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicLong storageUsed = new AtomicLong(0);
 
-    private volatile long storageCheckInterval;
+    private volatile long storageCheckIntervalMillis;
     private volatile List<Path> logDirs;
     private volatile Consumer<Long> consumer;
 
-    void configure(long storageCheckInterval, List<Path> logDirs, Consumer<Long> consumer) {
-        this.storageCheckInterval = storageCheckInterval;
+    void configure(long storageCheckIntervalMillis, List<Path> logDirs, Consumer<Long> consumer) {
+        this.storageCheckIntervalMillis = storageCheckIntervalMillis;
         this.logDirs = logDirs;
         this.consumer = consumer;
     }
 
     void startIfNecessary() {
-        if (running.compareAndSet(false, true) && storageCheckInterval > 0) {
+        if (running.compareAndSet(false, true) && storageCheckIntervalMillis > 0) {
             storageCheckerThread.setDaemon(true);
             storageCheckerThread.start();
         }
@@ -64,7 +63,7 @@ public class StorageChecker implements Runnable {
                             consumer.accept(diskUsage);
                         }
                         log.debug("Storage usage checked: {}", storageUsed.get());
-                        Thread.sleep(TimeUnit.SECONDS.toMillis(storageCheckInterval));
+                        Thread.sleep(storageCheckIntervalMillis);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         break;

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -5,12 +5,7 @@
 package io.strimzi.kafka.quotas;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.FileStore;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -31,45 +26,6 @@ class StaticQuotaCallbackTest {
     @AfterEach
     void tearDown() {
         target.close();
-    }
-
-    @Test
-    void testStorageCheckCheckDiskUsageZeroWhenMissing() throws IOException {
-        Path temp = Files.createTempDirectory("checkDiskUsage");
-        target.configure(Map.of("log.dirs", temp.toAbsolutePath().toString()));
-        Files.delete(temp);
-        assertEquals(0, target.storageChecker.checkDiskUsage());
-    }
-
-    @Test
-    void testStorageCheckCheckDiskUsageAtLeastFileSize() throws IOException {
-        Path tempDir = Files.createTempDirectory("checkDiskUsage");
-        Path tempFile = Files.createTempFile(tempDir, "t", ".tmp");
-        target.configure(Map.of("log.dirs", tempDir.toAbsolutePath().toString()));
-
-        try {
-            Files.writeString(tempFile, "0123456789");
-            long minSize = Files.size(tempFile);
-            assertTrue(target.storageChecker.checkDiskUsage() >= minSize);
-        } finally {
-            Files.delete(tempFile);
-            Files.delete(tempDir);
-        }
-    }
-
-    @Test
-    void testStorageCheckCheckDiskUsageNotDoubled() throws IOException {
-        Path tempDir1 = Files.createTempDirectory("checkDiskUsage");
-        Path tempDir2 = Files.createTempDirectory("checkDiskUsage");
-        target.configure(Map.of("log.dirs", String.format("%s,%s", tempDir1.toAbsolutePath(), tempDir2.toAbsolutePath())));
-
-        try {
-            FileStore store = Files.getFileStore(tempDir1);
-            assertEquals(store.getTotalSpace() - store.getUsableSpace(), target.storageChecker.checkDiskUsage());
-        } finally {
-            Files.delete(tempDir1);
-            Files.delete(tempDir2);
-        }
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021, Red Hat Inc.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.quotas;
+
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StorageCheckerTest {
+
+    StorageChecker target;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup() {
+        target = new StorageChecker();
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        if (target != null) {
+            target.stop();
+        }
+    }
+
+    @Test
+    void storageCheckCheckDiskUsageZeroWhenMissing() throws Exception {
+        target.configure(0, List.of(tempDir), storage -> { });
+        Files.delete(tempDir);
+        assertEquals(0, target.checkDiskUsage());
+    }
+
+    @Test
+    void storageCheckCheckDiskUsageAtLeastFileSize() throws Exception {
+        Path tempFile = Files.createTempFile(tempDir, "t", ".tmp");
+        target.configure(0, List.of(tempDir), storage -> { });
+
+        Files.writeString(tempFile, "0123456789");
+        long minSize = Files.size(tempFile);
+        assertTrue(target.checkDiskUsage() >= minSize);
+    }
+
+    @Test
+    void storageCheckCheckDiskUsageNotDoubled(@TempDir Path tempDir1, @TempDir Path tempDir2) throws Exception {
+        target.configure(0, List.of(tempDir1, tempDir2), storage -> { });
+
+        FileStore store = Files.getFileStore(tempDir1);
+        assertEquals(store.getTotalSpace() - store.getUsableSpace(), target.checkDiskUsage());
+    }
+
+    @Test
+    void testStorageCheckerEmitsUsedStorageValue() throws Exception {
+        Path tempFile = Files.createTempFile(tempDir, "t", ".tmp");
+        Files.writeString(tempFile, "0123456789");
+        long minSize = Files.size(tempFile);
+
+        CompletableFuture<Long> completableFuture = new CompletableFuture<>();
+        target.configure(25, List.of(tempDir), completableFuture::complete);
+        target.startIfNecessary();
+
+        Long storage = completableFuture.get(1, TimeUnit.SECONDS);
+        assertTrue(storage >= minSize);
+    }
+}


### PR DESCRIPTION
The intent of this refactoring is merely to decouple StorageChecker from StaticQuotaCallback, to facilitate better unit-cases.

Signed-off-by: kwall <kwall@apache.org>