### PR TITLE
Metric improvements - Expose hard quota, produce, fetch, requests limits as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ client.quota.callback.static.excluded.principal.name.list=principal1,principal2
 
 ## Metrics
 
-The plugin currently provides 6 metrics:
+The plugin currently provides the following metrics:
 * `io.strimzi.kafka.quotas:type=StorageChecker,name=TotalStorageUsedBytes` shows the current storage usage
 * `io.strimzi.kafka.quotas:type=StorageChecker,name=SoftLimitBytes` shows the currently configured soft limit
 * `io.strimzi.kafka.quotas:type=StorageChecker,name=HardLimitBytes` shows the currently configured hard limit

--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ client.quota.callback.static.excluded.principal.name.list=principal1,principal2
 
 ## Metrics
 
-The plugin currently provides 2 metrics:
+The plugin currently provides 6 metrics:
 * `io.strimzi.kafka.quotas:type=StorageChecker,name=TotalStorageUsedBytes` shows the current storage usage
 * `io.strimzi.kafka.quotas:type=StorageChecker,name=SoftLimitBytes` shows the currently configured soft limit
+* `io.strimzi.kafka.quotas:type=StorageChecker,name=HardLimitBytes` shows the currently configured hard limit
+* `io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=Produce` shows the currently configured produce quota
+* `io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=Fetch` shows the currently configured fetch quota
+* `io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=Request` shows the currently configured request quota
 
 ## Building
 

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -191,8 +191,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         String group = clazz.getPackageName();
         String type = clazz.getSimpleName();
         String mBeanName = String.format("%s:type=%s,name=%s", group, type, name);
-        MetricName storageChecker = new MetricName(group, type, name, this.scope, mBeanName);
-        return storageChecker;
+        return new MetricName(group, type, name, this.scope, mBeanName);
     }
 
     private static class ClientQuotaGauge extends Gauge<Double> {

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -26,7 +26,7 @@ import org.apache.kafka.server.quota.ClientQuotaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.Locale.ROOT;
+import static java.util.Locale.ENGLISH;
 
 /**
  * Allows configuring generic quotas for a broker independent of users and clients.
@@ -175,7 +175,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         });
 
         quotaMap.forEach((clientQuotaType, quota) -> {
-            String name = clientQuotaType.name().toUpperCase(ROOT).charAt(0) + clientQuotaType.name().toLowerCase(ROOT).substring(1);
+            String name = clientQuotaType.name().toUpperCase(ENGLISH).charAt(0) + clientQuotaType.name().toLowerCase(ENGLISH).substring(1);
             Metrics.newGauge(metricName(StaticQuotaCallback.class, name), new ClientQuotaGauge(quota));
         });
     }

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -15,8 +15,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
 import java.util.function.Consumer;
 
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.server.quota.ClientQuotaType;
 import org.junit.jupiter.api.AfterEach;
@@ -103,5 +109,73 @@ class StaticQuotaCallbackTest {
         assertTrue(quotaCallback.quotaResetRequired(ClientQuotaType.PRODUCE), "unexpected state on subsequent call after 2nd storage state change");
 
         quotaCallback.close();
+    }
+
+    @Test
+    void storageCheckerMetrics() {
+        StorageChecker mock = mock(StorageChecker.class);
+        ArgumentCaptor<Consumer<Long>> argument = ArgumentCaptor.forClass(Consumer.class);
+        doNothing().when(mock).configure(anyLong(), anyList(), argument.capture());
+
+        StaticQuotaCallback quotaCallback = new StaticQuotaCallback(mock);
+
+        quotaCallback.configure(Map.of(
+                StaticQuotaConfig.STORAGE_QUOTA_SOFT_PROP, 15L,
+                StaticQuotaConfig.STORAGE_QUOTA_HARD_PROP, 16L
+        ));
+
+        argument.getValue().accept(17L);
+
+        SortedMap<MetricName, Metric> group = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "StorageChecker");
+
+        assertGaugeMetric(group, "SoftLimitBytes", 15L);
+        assertGaugeMetric(group, "HardLimitBytes", 16L);
+        assertGaugeMetric(group, "TotalStorageUsedBytes", 17L);
+
+        // the mbean name is part of the public api
+        MetricName name = group.firstKey();
+        String expectedMbeanName = String.format("io.strimzi.kafka.quotas:type=StorageChecker,name=%s", name.getName());
+        assertEquals(expectedMbeanName, name.getMBeanName(), "unexpected mbean name");
+
+        quotaCallback.close();
+    }
+
+    @Test
+    void staticQuotaMetrics() {
+
+        target.configure(Map.of(
+                StaticQuotaConfig.PRODUCE_QUOTA_PROP, 15.0,
+                StaticQuotaConfig.FETCH_QUOTA_PROP, 16.0,
+                StaticQuotaConfig.REQUEST_QUOTA_PROP, 17.0
+        ));
+
+        SortedMap<MetricName, Metric> group = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "StaticQuotaCallback");
+
+        assertGaugeMetric(group, "Produce", 15.0);
+        assertGaugeMetric(group, "Fetch", 16.0);
+        assertGaugeMetric(group, "Request", 17.0);
+
+        // the mbean name is part of the public api
+        MetricName name = group.firstKey();
+        String expectedMbeanName = String.format("io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=%s", name.getName());
+        assertEquals(expectedMbeanName, name.getMBeanName(), "unexpected mbean name");
+    }
+
+    private SortedMap<MetricName, Metric> getMetricGroup(String p, String t) {
+        SortedMap<String, SortedMap<MetricName, Metric>> storageMetrics = Metrics.defaultRegistry().groupedMetrics((name, metric) -> p.equals(name.getScope()) && t.equals(name.getType()));
+        assertEquals(1, storageMetrics.size(), "unexpected number of metrics in group");
+        return storageMetrics.entrySet().iterator().next().getValue();
+    }
+
+    private <T> void assertGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, T expected) {
+        Optional<Gauge<T>> desired = findGaugeMetric(metrics, name);
+        assertTrue(desired.isPresent(), String.format("metric with name %s not found in %s", name, metrics));
+        Gauge<T> gauge = desired.get();
+        assertEquals(expected, gauge.value(), String.format("metric %s has unexpected value", name));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Optional<Gauge<T>> findGaugeMetric(SortedMap<MetricName, Metric> metrics, String name) {
+        return metrics.entrySet().stream().filter(e -> name.equals(e.getKey().getName())).map(e -> (Gauge<T>) e.getValue()).findFirst();
     }
 }


### PR DESCRIPTION
Metric improvements - Expose hard quota, produce, fetch, requests limits as metrics

* expose hard quota limit (#15)
* expose produce, fetch, request limits as limit metrics
* unit tests added

use-case for produce, fetch, requests limits as metrics is the same as having the soft/hard quota limits as metrics.   Having these values available for digest into your metrics stack is powerful, as it enables the user to visualise how close an application is running wrt its limits. 

