### PR TITLE
Thread to scheduler

### DIFF
--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -63,7 +63,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         }));
     }
 
-    StaticQuotaCallback(StorageChecker storageChecker, ScheduledExecutorService backgroundScheduler) {
+    /*test*/ StaticQuotaCallback(StorageChecker storageChecker, ScheduledExecutorService backgroundScheduler) {
         this.storageChecker = storageChecker;
         this.backgroundScheduler = backgroundScheduler;
         Collections.addAll(resetQuota, ClientQuotaType.values());
@@ -166,7 +166,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
             storageChecker.configure(
                     logDirs,
                     this::updateUsedStorage);
-            storageCheckerFuture = backgroundScheduler.scheduleAtFixedRate(storageChecker, storageCheckIntervalMillis, storageCheckIntervalMillis, TimeUnit.MILLISECONDS);
+            backgroundScheduler.scheduleWithFixedDelay(storageChecker, storageCheckIntervalMillis, storageCheckIntervalMillis, TimeUnit.MILLISECONDS);
             log.info("Configured quota callback with {}. Storage quota (soft, hard): ({}, {}). Storage check interval: {}ms", quotaMap, storageQuotaSoft, storageQuotaHard, storageCheckIntervalMillis);
         }
         if (!excludedPrincipalNameList.isEmpty()) {

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -53,7 +52,6 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     private final String scope = "io.strimzi.kafka.quotas.StaticQuotaCallback";
 
     private final ScheduledExecutorService backgroundScheduler;
-    private ScheduledFuture<?> storageCheckerFuture;
 
     public StaticQuotaCallback() {
         this(new StorageChecker(), Executors.newSingleThreadScheduledExecutor(r -> {
@@ -158,9 +156,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         excludedPrincipalNameList = config.getExcludedPrincipalNameList();
 
         long storageCheckIntervalMillis = TimeUnit.SECONDS.toMillis(config.getStorageCheckInterval());
-        if (storageCheckerFuture != null) {
-            storageCheckerFuture.cancel(true);
-        }
+
         if (storageCheckIntervalMillis > 0L) {
             List<Path> logDirs = config.getLogDirs().stream().map(Paths::get).collect(Collectors.toList());
             storageChecker.configure(

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -31,14 +31,6 @@ public class StorageChecker implements Runnable {
         this.consumer = consumer;
     }
 
-    void startIfNecessary() {
-
-    }
-
-    void stop() throws InterruptedException {
-
-    }
-
     @Override
     public void run() {
         if (logDirs != null && !logDirs.isEmpty()) {

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -4,17 +4,16 @@
  */
 package io.strimzi.kafka.quotas;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Periodically reports the total storage used by one or more filesystems.
@@ -22,32 +21,22 @@ import java.util.function.Consumer;
 public class StorageChecker implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(StorageChecker.class);
 
-    private final Thread storageCheckerThread = new Thread(this, "storage-quota-checker");
-    private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicLong storageUsed = new AtomicLong(0);
 
-    private volatile long storageCheckIntervalMillis;
     private volatile List<Path> logDirs;
     private volatile Consumer<Long> consumer;
 
-    void configure(long storageCheckIntervalMillis, List<Path> logDirs, Consumer<Long> consumer) {
-        this.storageCheckIntervalMillis = storageCheckIntervalMillis;
+    void configure(List<Path> logDirs, Consumer<Long> consumer) {
         this.logDirs = logDirs;
         this.consumer = consumer;
     }
 
     void startIfNecessary() {
-        if (running.compareAndSet(false, true) && storageCheckIntervalMillis > 0) {
-            storageCheckerThread.setDaemon(true);
-            storageCheckerThread.start();
-        }
+
     }
 
     void stop() throws InterruptedException {
-        if (running.compareAndSet(true, false)) {
-            storageCheckerThread.interrupt();
-            storageCheckerThread.join();
-        }
+
     }
 
     @Override
@@ -55,21 +44,15 @@ public class StorageChecker implements Runnable {
         if (logDirs != null && !logDirs.isEmpty()) {
             try {
                 log.info("Quota Storage Checker is now starting");
-                while (running.get()) {
-                    try {
-                        long diskUsage = checkDiskUsage();
-                        long previousUsage = storageUsed.getAndSet(diskUsage);
-                        if (diskUsage != previousUsage) {
-                            consumer.accept(diskUsage);
-                        }
-                        log.debug("Storage usage checked: {}", storageUsed.get());
-                        Thread.sleep(storageCheckIntervalMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    } catch (Exception e) {
-                        log.warn("Exception in storage checker thread", e);
+                try {
+                    long diskUsage = checkDiskUsage();
+                    long previousUsage = storageUsed.getAndSet(diskUsage);
+                    if (diskUsage != previousUsage) {
+                        consumer.accept(diskUsage);
                     }
+                    log.debug("Storage usage checked: {}", storageUsed.get());
+                } catch (Exception e) {
+                    log.warn("Exception in storage checker thread", e);
                 }
             } finally {
                 log.info("Quota Storage Checker is now finishing");

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -101,7 +101,7 @@ class StaticQuotaCallbackTest {
         target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
 
         //Verify
-        verify(scheduledExecutorService, times(1)).scheduleAtFixedRate(any(), eq(1000L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+        verify(scheduledExecutorService, times(1)).scheduleWithFixedDelay(any(), eq(1000L), eq(1000L), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -115,7 +115,7 @@ class StaticQuotaCallbackTest {
         target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "0"));
 
         //Then
-        verify(scheduledExecutorService, times(0)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any(TimeUnit.class));
+        verify(scheduledExecutorService, times(0)).scheduleWithFixedDelay(any(), anyLong(), anyLong(), any(TimeUnit.class));
     }
 
     @Test
@@ -129,7 +129,7 @@ class StaticQuotaCallbackTest {
         target.configure(Map.of());
 
         //Then
-        verify(scheduledExecutorService, times(0)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any(TimeUnit.class));
+        verify(scheduledExecutorService, times(0)).scheduleWithFixedDelay(any(), anyLong(), anyLong(), any(TimeUnit.class));
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -40,7 +40,8 @@ import static org.mockito.Mockito.when;
 
 class StaticQuotaCallbackTest {
 
-    public static final Map<String, Integer> MINIMUM_VALID_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10);
+    public static final Map<String, Integer> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10);
+
     StaticQuotaCallback target;
 
     ScheduledExecutorService backgroundScheduler = Executors.newSingleThreadScheduledExecutor();
@@ -123,7 +124,7 @@ class StaticQuotaCallbackTest {
         StorageChecker storageChecker = mock(StorageChecker.class);
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         StaticQuotaCallback target = new StaticQuotaCallback(storageChecker, scheduledExecutorService);
-        target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
+        target.configure(MINIMUM_EXECUTABLE_CONFIG);
 
         //When
         target.close();
@@ -142,10 +143,10 @@ class StaticQuotaCallbackTest {
         when(scheduledExecutorService.scheduleAtFixedRate(any(), anyLong(), anyLong(), any())).thenReturn(scheduledFuture);
 
         StaticQuotaCallback target = new StaticQuotaCallback(storageChecker, scheduledExecutorService);
-        target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
+        target.configure(MINIMUM_EXECUTABLE_CONFIG);
 
         //When
-        target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
+        target.configure(MINIMUM_EXECUTABLE_CONFIG);
 
         //Then
         verify(scheduledFuture).cancel(anyBoolean());
@@ -159,7 +160,7 @@ class StaticQuotaCallbackTest {
         ArgumentCaptor<Consumer<Long>> argument = ArgumentCaptor.forClass(Consumer.class);
         doNothing().when(mock).configure(anyList(), argument.capture());
         StaticQuotaCallback quotaCallback = new StaticQuotaCallback(mock, backgroundScheduler);
-        quotaCallback.configure(MINIMUM_VALID_CONFIG);
+        quotaCallback.configure(MINIMUM_EXECUTABLE_CONFIG);
         Consumer<Long> storageUpdateConsumer = argument.getValue();
         quotaCallback.updateClusterMetadata(null);
 
@@ -186,7 +187,7 @@ class StaticQuotaCallbackTest {
         ArgumentCaptor<Consumer<Long>> argument = ArgumentCaptor.forClass(Consumer.class);
         doNothing().when(mock).configure(anyList(), argument.capture());
         StaticQuotaCallback quotaCallback = new StaticQuotaCallback(mock, backgroundScheduler);
-        quotaCallback.configure(MINIMUM_VALID_CONFIG);
+        quotaCallback.configure(MINIMUM_EXECUTABLE_CONFIG);
         Consumer<Long> storageUpdateConsumer = argument.getValue();
         quotaCallback.updateClusterMetadata(null);
 

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class StaticQuotaCallbackTest {
 
@@ -127,6 +130,26 @@ class StaticQuotaCallbackTest {
 
         //Verify
         verify(scheduledExecutorService, times(1)).shutdownNow();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    void shouldCancelExisting() {
+        //Given
+        StorageChecker storageChecker = mock(StorageChecker.class);
+        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+        final ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
+        when(scheduledExecutorService.scheduleAtFixedRate(any(), anyLong(), anyLong(), any())).thenReturn(scheduledFuture);
+
+        StaticQuotaCallback target = new StaticQuotaCallback(storageChecker, scheduledExecutorService);
+        target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
+
+        //When
+        target.configure(Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "1"));
+
+        //Then
+        verify(scheduledFuture).cancel(anyBoolean());
+
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -28,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,7 +34,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class StaticQuotaCallbackTest {
 
@@ -145,26 +142,6 @@ class StaticQuotaCallbackTest {
 
         //Verify
         verify(scheduledExecutorService, times(1)).shutdownNow();
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Test
-    void shouldCancelExisting() {
-        //Given
-        StorageChecker storageChecker = mock(StorageChecker.class);
-        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
-        final ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
-        when(scheduledExecutorService.scheduleAtFixedRate(any(), anyLong(), anyLong(), any())).thenReturn(scheduledFuture);
-
-        StaticQuotaCallback target = new StaticQuotaCallback(storageChecker, scheduledExecutorService);
-        target.configure(MINIMUM_EXECUTABLE_CONFIG);
-
-        //When
-        target.configure(MINIMUM_EXECUTABLE_CONFIG);
-
-        //Then
-        verify(scheduledFuture).cancel(anyBoolean());
-
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -119,6 +119,20 @@ class StaticQuotaCallbackTest {
     }
 
     @Test
+    void shouldNotScheduleStorageCheckWhenCheckIntervalIsNotProvided() {
+        //Given
+        StorageChecker storageChecker = mock(StorageChecker.class);
+        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+        StaticQuotaCallback target = new StaticQuotaCallback(storageChecker, scheduledExecutorService);
+
+        //When
+        target.configure(Map.of());
+
+        //Then
+        verify(scheduledExecutorService, times(0)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
     void shouldShutdownExecutorOnClose() {
         //Given
         StorageChecker storageChecker = mock(StorageChecker.class);

--- a/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
@@ -40,7 +40,7 @@ public class StorageCheckerTest {
 
     @Test
     void storageCheckCheckDiskUsageZeroWhenMissing() throws Exception {
-        target.configure(0, List.of(tempDir), storage -> { });
+        target.configure(List.of(tempDir), storage -> { });
         Files.delete(tempDir);
         assertEquals(0, target.checkDiskUsage());
     }
@@ -48,7 +48,7 @@ public class StorageCheckerTest {
     @Test
     void storageCheckCheckDiskUsageAtLeastFileSize() throws Exception {
         Path tempFile = Files.createTempFile(tempDir, "t", ".tmp");
-        target.configure(0, List.of(tempDir), storage -> { });
+        target.configure(List.of(tempDir), storage -> { });
 
         Files.writeString(tempFile, "0123456789");
         long minSize = Files.size(tempFile);
@@ -57,7 +57,7 @@ public class StorageCheckerTest {
 
     @Test
     void storageCheckCheckDiskUsageNotDoubled(@TempDir Path tempDir1, @TempDir Path tempDir2) throws Exception {
-        target.configure(0, List.of(tempDir1, tempDir2), storage -> { });
+        target.configure(List.of(tempDir1, tempDir2), storage -> { });
 
         FileStore store = Files.getFileStore(tempDir1);
         assertEquals(store.getTotalSpace() - store.getUsableSpace(), target.checkDiskUsage());
@@ -70,8 +70,8 @@ public class StorageCheckerTest {
         long minSize = Files.size(tempFile);
 
         CompletableFuture<Long> completableFuture = new CompletableFuture<>();
-        target.configure(25, List.of(tempDir), completableFuture::complete);
-        target.startIfNecessary();
+        target.configure(List.of(tempDir), completableFuture::complete);
+        target.run();
 
         Long storage = completableFuture.get(1, TimeUnit.SECONDS);
         assertTrue(storage >= minSize);

--- a/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StorageCheckerTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -29,13 +28,6 @@ public class StorageCheckerTest {
     @BeforeEach
     void setup() {
         target = new StorageChecker();
-    }
-
-    @AfterEach
-    void teardown() throws Exception {
-        if (target != null) {
-            target.stop();
-        }
     }
 
     @Test


### PR DESCRIPTION
Instead of dedicating a single thread to the storage checker and managing it directly use a, potentially shared, Scheduled Executor service to manage the background tasks.
 
Separating this out from the work for https://github.com/strimzi/kafka-quotas-plugin/issues/28 to try and keep the reviews more manageable. 

Having a scheduled executor proved to be quite valuable in the internal version of the quota plugin we developed, and we want to replace with the KIP-827 based version, as it made handling multiple background jobs much simpler. It also improves separation of concerns so that the storage checker is focused on evaluating storage usage rather than thread management.