### PR TITLE
Basic support for KIP-827 consider all cluster volumes when throttling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,13 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-        <kafka.version>3.0.0</kafka.version>
+        <kafka.version>3.3.1</kafka.version>
         <slf4j.version>1.7.30</slf4j.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <junit.version>5.7.2</junit.version>
-        <mockito.version>2.28.2</mockito.version>
+        <mockito.version>4.4.0</mockito.version>
+        <assertj.version>3.22.0</assertj.version>
+        <jimfs.version>1.2</jimfs.version>
 
         <!-- property to skip surefire tests during failsafe execution -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -144,6 +146,27 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>${jimfs.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,18 @@
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -138,7 +150,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/strimzi/kafka/quotas/ClusterVolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/ClusterVolumeSource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.common.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toSet;
+
+public class ClusterVolumeSource implements Runnable {
+
+    private final Consumer<Collection<Volume>> volumeConsumer;
+    private final Admin admin;
+
+    private static final Logger log = LoggerFactory.getLogger(ClusterVolumeSource.class);
+
+    public ClusterVolumeSource(Admin admin, Consumer<Collection<Volume>> volumeConsumer) {
+        this.volumeConsumer = volumeConsumer;
+        this.admin = admin;
+    }
+
+    @Override
+    public void run() {
+        log.debug("Attempting to describe cluster");
+        final DescribeClusterResult clusterResult = admin.describeCluster();
+        clusterResult.nodes().whenComplete((nodes, throwable) -> {
+            if (throwable != null) {
+                log.error("error while describing cluster", throwable);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Successfully described cluster: " + nodes);
+                }
+                onClusterDescribeSuccess(nodes);
+            }
+        });
+    }
+
+    private void onClusterDescribeSuccess(Collection<Node> nodes) {
+        final Set<Integer> allBrokerIds = nodes.stream().map(Node::id).collect(toSet());
+        final DescribeLogDirsResult logDirsResult = admin.describeLogDirs(allBrokerIds);
+        logDirsResult.allDescriptions().whenComplete((logDirsPerBroker, throwable) -> {
+            if (throwable != null) {
+                log.error("error while describing log dirs", throwable);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Successfully described logDirs: " + logDirsPerBroker);
+                }
+                onDescribeLogDirsSuccess(logDirsPerBroker);
+            }
+        });
+    }
+
+    private void onDescribeLogDirsSuccess(Map<Integer, Map<String, LogDirDescription>> logDirsPerBroker) {
+        final List<Volume> volumes = logDirsPerBroker.entrySet().stream()
+                .flatMap(ClusterVolumeSource::toVolumes).collect(Collectors.toUnmodifiableList());
+        if (log.isDebugEnabled()) {
+            log.debug("Notifying consumers of volumes: " + volumes);
+        }
+        volumeConsumer.accept(volumes);
+    }
+
+
+    private static Stream<? extends Volume> toVolumes(Map.Entry<Integer, Map<String, LogDirDescription>> brokerIdToLogDirs) {
+        return brokerIdToLogDirs.getValue().entrySet().stream().map(logDirs -> {
+            LogDirDescription logDirDescription = logDirs.getValue();
+            final long totalBytes = logDirDescription.totalBytes().orElse(0);
+            final long usableBytes = logDirDescription.usableBytes().orElse(0);
+            return new Volume("" + brokerIdToLogDirs.getKey(), logDirs.getKey(), totalBytes, usableBytes);
+        });
+    }
+
+}

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -202,13 +202,9 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
 
     private void updateVolumes(Collection<Volume> volumes) {
         final long totalConsumedSpace = volumes.stream().mapToLong(Volume::getConsumedSpace).sum();
-        updateUsedStorage(totalConsumedSpace);
-    }
-
-
-    private void updateUsedStorage(Long newValue) {
-        var oldValue = storageUsed.getAndSet(newValue);
-        if (oldValue != newValue) {
+        var oldValue = storageUsed.getAndSet(totalConsumedSpace);
+        log.debug("Storage usage checked: {}", totalConsumedSpace);
+        if (oldValue != totalConsumedSpace) {
             resetQuota.add(ClientQuotaType.PRODUCE);
         }
     }

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -4,21 +4,34 @@
  */
 package io.strimzi.kafka.quotas;
 
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.metrics.Quota;
-import org.apache.kafka.server.quota.ClientQuotaType;
-
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.metrics.Quota;
+import org.apache.kafka.server.quota.ClientQuotaType;
+import org.slf4j.Logger;
 
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
+import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Type.DOUBLE;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
+import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Configuration for the static quota plugin.
@@ -32,6 +45,13 @@ public class StaticQuotaConfig extends AbstractConfig {
     static final String STORAGE_QUOTA_HARD_PROP = "client.quota.callback.static.storage.hard";
     static final String STORAGE_CHECK_INTERVAL_PROP = "client.quota.callback.static.storage.check-interval";
     static final String LOG_DIRS_PROP = "log.dirs";
+    public static final String VOLUME_SOURCE_PROP = "client.quota.callback.static.storage.volume.source";
+    private final KafkaClientConfig kafkaClientConfig;
+
+    public enum VolumeSource {
+        CLUSTER,
+        LOCAL,
+    }
 
     /**
      * Construct a configuration for the static quota plugin.
@@ -47,9 +67,11 @@ public class StaticQuotaConfig extends AbstractConfig {
                         .define(STORAGE_QUOTA_SOFT_PROP, LONG, Long.MAX_VALUE, HIGH, "Hard limit for amount of storage allowed (in bytes)")
                         .define(STORAGE_QUOTA_HARD_PROP, LONG, Long.MAX_VALUE, HIGH, "Soft limit for amount of storage allowed (in bytes)")
                         .define(STORAGE_CHECK_INTERVAL_PROP, INT, 0, MEDIUM, "Interval between storage check runs (in seconds, default of 0 means disabled")
+                        .define(VOLUME_SOURCE_PROP, STRING, "local", enumValidator(), HIGH, "Where to source volume usage information from.") //TODO Potentially values should be an enum
                         .define(LOG_DIRS_PROP, LIST, List.of(), HIGH, "Broker log directories"),
                 props,
                 doLog);
+        kafkaClientConfig = new KafkaClientConfig(props, doLog);
     }
 
     Map<ClientQuotaType, Quota> getQuotaMap() {
@@ -84,5 +106,74 @@ public class StaticQuotaConfig extends AbstractConfig {
     List<String> getExcludedPrincipalNameList() {
         return getList(EXCLUDED_PRINCIPAL_NAME_LIST_PROP);
     }
+
+    KafkaClientConfig getKafkaClientConfig() {
+        return kafkaClientConfig;
+    }
+
+    public VolumeSource getVolumeSource() {
+        return VolumeSource.valueOf(getString(VOLUME_SOURCE_PROP).toUpperCase(Locale.ROOT));
+    }
+
+    private static ConfigDef.LambdaValidator enumValidator() {
+        return ConfigDef.LambdaValidator.with((name, value) -> VolumeSource.valueOf(String.valueOf(value).toUpperCase(Locale.ROOT)), () -> "Must be one of " + Arrays.toString(VolumeSource.values()));
+    }
+
+    static class KafkaClientConfig extends AbstractConfig {
+        public static final String LISTENER_NAME_PROP = "client.quota.callback.kafka.listener.name";
+        public static final String LISTENER_PORT_PROP = "client.quota.callback.kafka.listener.port";
+        public static final String LISTENER_PROTOCOL_PROP = "client.quota.callback.kafka.listener.protocol";
+        public static final String CLIENT_ID_PREFIX_PROP = "client.quota.callback.kafka.clientIdPrefix";
+        private final Logger log = getLogger(KafkaClientConfig.class);
+
+        public KafkaClientConfig(Map<String, ?> props, boolean doLog) {
+            super(new ConfigDef()
+                            .define(LISTENER_NAME_PROP, STRING, "replication-9091", LOW, "which listener to connect to")
+                            .define(LISTENER_PORT_PROP, INT, 9091, LOW, "which port to connect to the listener on")
+                            .define(LISTENER_PROTOCOL_PROP, STRING, "SSL", LOW, "what protocol to use when connecting to the listener")
+                            .define(CLIENT_ID_PREFIX_PROP, STRING, "__strimzi", LOW, "Prefix to use when creating client.ids"),
+                    props,
+                    doLog);
+        }
+
+        public Map<String, Object> getKafkaClientConfig() {
+            final String bootstrapAddress = getBootstrapAddress();
+
+            final Map<String, Object> configuredProperties = Stream.concat(
+                            Stream.of(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+                                            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+                                            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+                                            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)
+                                    .map(p -> {
+                                        String configKey = String.format("listener.name.%s.%s", getString(LISTENER_NAME_PROP), p);
+                                        String v = getOriginalConfigString(configKey);
+                                        return Map.entry(p, Objects.requireNonNullElse(v, ""));
+                                    })
+                                    .filter(e -> !e.getValue().trim().isEmpty()),
+                            Stream.of(Map.entry(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress),
+                                    Map.entry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, getString(LISTENER_PROTOCOL_PROP))))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            log.info("resolved kafka config of {}", configuredProperties);
+            return configuredProperties;
+        }
+
+        private String getBootstrapAddress() {
+            final Integer listenerPort = getInt(LISTENER_PORT_PROP);
+            String hostname;
+            try {
+                hostname = InetAddress.getLocalHost().getCanonicalHostName();
+            } catch (UnknownHostException e) {
+                log.warn("Unable to get canonical hostname for localhost: {} defaulting to 127.0.0.1:{}", e.getMessage(), listenerPort, e);
+                hostname = "127.0.0.1";
+            }
+            return String.format("%s:%s", hostname, listenerPort);
+        }
+
+        private String getOriginalConfigString(String configKey) {
+            return (String) originals().get(configKey);
+        }
+
+    }
+
 }
 

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -8,9 +8,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,9 +26,9 @@ public class StorageChecker implements Runnable {
     private final AtomicLong storageUsed = new AtomicLong(0);
 
     private volatile List<Path> logDirs;
-    private volatile Consumer<Long> consumer;
+    private volatile Consumer<Collection<Volume>> consumer;
 
-    void configure(List<Path> logDirs, Consumer<Long> consumer) {
+    void configure(List<Path> logDirs, Consumer<Collection<Volume>> consumer) {
         this.logDirs = logDirs;
         this.consumer = consumer;
     }
@@ -37,9 +39,10 @@ public class StorageChecker implements Runnable {
             try {
                 log.info("Quota Storage Checker is now starting");
                 try {
-                    long diskUsage = checkDiskUsage();
-                    long previousUsage = storageUsed.getAndSet(diskUsage);
-                    if (diskUsage != previousUsage) {
+                    Collection<Volume> diskUsage = checkDiskUsage();
+                    final long totalUsed = diskUsage.stream().mapToLong(Volume::getConsumedSpace).sum();
+                    long previousUsage = storageUsed.getAndSet(totalUsed);
+                    if (totalUsed != previousUsage) {
                         consumer.accept(diskUsage);
                     }
                     log.debug("Storage usage checked: {}", storageUsed.get());
@@ -52,13 +55,14 @@ public class StorageChecker implements Runnable {
         }
     }
 
-    long checkDiskUsage() {
+    Collection<Volume> checkDiskUsage() {
         return logDirs.stream()
                 .filter(Files::exists)
                 .map(path -> apply(() -> Files.getFileStore(path)))
                 .distinct()
-                .mapToLong(store -> apply(() -> store.getTotalSpace() - store.getUsableSpace()))
-                .sum();
+                .map(store -> new Volume("-1", apply(store::name), apply(store::getTotalSpace),
+                        apply(store::getUsableSpace)))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     static <T> T apply(IOSupplier<T> supplier) {

--- a/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StorageChecker.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -22,8 +21,6 @@ import org.slf4j.LoggerFactory;
  */
 public class StorageChecker implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(StorageChecker.class);
-
-    private final AtomicLong storageUsed = new AtomicLong(0);
 
     private volatile List<Path> logDirs;
     private volatile Consumer<Collection<Volume>> consumer;
@@ -39,13 +36,7 @@ public class StorageChecker implements Runnable {
             try {
                 log.info("Quota Storage Checker is now starting");
                 try {
-                    Collection<Volume> diskUsage = checkDiskUsage();
-                    final long totalUsed = diskUsage.stream().mapToLong(Volume::getConsumedSpace).sum();
-                    long previousUsage = storageUsed.getAndSet(totalUsed);
-                    if (totalUsed != previousUsage) {
-                        consumer.accept(diskUsage);
-                    }
-                    log.debug("Storage usage checked: {}", storageUsed.get());
+                    consumer.accept(checkDiskUsage());
                 } catch (Exception e) {
                     log.warn("Exception in storage checker thread", e);
                 }

--- a/src/main/java/io/strimzi/kafka/quotas/Volume.java
+++ b/src/main/java/io/strimzi/kafka/quotas/Volume.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.Objects;
+
+public class Volume {
+    private final String brokerId;
+    private final String logDir;
+    private final long capacity;
+    private final long usableBytes;
+
+    public Volume(String brokerId, String logDir, long capacity, long usableBytes) {
+        this.brokerId = brokerId;
+        this.logDir = logDir;
+        this.capacity = capacity;
+        this.usableBytes = usableBytes;
+    }
+
+    public String getBrokerId() {
+        return brokerId;
+    }
+
+    public String getLogDir() {
+        return logDir;
+    }
+
+    public long getCapacity() {
+        return capacity;
+    }
+
+    public long getConsumedSpace() {
+        return capacity - usableBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Volume volume = (Volume) o;
+        return capacity == volume.capacity && usableBytes == volume.usableBytes && Objects.equals(brokerId, volume.brokerId) && Objects.equals(logDir, volume.logDir);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(brokerId, logDir, capacity, usableBytes);
+    }
+
+    @Override
+    public String toString() {
+        return "Volume{" +
+                "brokerId='" + brokerId + '\'' +
+                ", name='" + logDir + '\'' +
+                ", capacity=" + capacity +
+                ", usableBytes=" + usableBytes +
+                '}';
+    }
+}

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.quotas;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.LogDirDescription;
+
+public class VolumeSourceBuilder implements AutoCloseable {
+
+    private final Supplier<Boolean> kip827Available;
+    private AdminClient adminClient;
+    private StaticQuotaConfig config;
+    private Consumer<Collection<Volume>> volumesConsumer;
+
+    public VolumeSourceBuilder() {
+        this(() -> {
+            try {
+                LogDirDescription.class.getDeclaredMethod("totalBytes");
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
+            }
+        });
+    }
+
+    /* test */ VolumeSourceBuilder(Supplier<Boolean> kip827Available) {
+        this.kip827Available = kip827Available;
+    }
+
+    public VolumeSourceBuilder withConfig(StaticQuotaConfig config) {
+        this.config = config;
+        return this;
+    }
+
+    public VolumeSourceBuilder withVolumeConsumer(Consumer<Collection<Volume>> volumesConsumer) {
+        this.volumesConsumer = volumesConsumer;
+        return this;
+    }
+
+    Runnable build() {
+        switch (config.getVolumeSource()) {
+            case CLUSTER:
+                if (!kip827Available.get()) {
+                    throw new IllegalStateException("Cluster volume source selected but KIP-827 not available");
+                }
+                final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = config.getKafkaClientConfig();
+                adminClient = AdminClient.create(kafkaClientConfig.getKafkaClientConfig());
+                return new ClusterVolumeSource(adminClient, volumesConsumer);
+            case LOCAL: //make it explicit
+            default:
+                List<Path> logDirs = config.getLogDirs().stream().map(Paths::get).collect(Collectors.toList());
+                StorageChecker storageChecker = new StorageChecker();
+                storageChecker.configure(
+                        logDirs,
+                        volumesConsumer);
+                return storageChecker;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (adminClient != null) {
+            adminClient.close();
+        }
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/ClusterVolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/ClusterVolumeSourceTest.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,10 +47,10 @@ class ClusterVolumeSourceTest {
     void setUp() {
         volumeConsumer = new VolumeConsumer();
         clusterVolumeSource = new ClusterVolumeSource(admin, volumeConsumer);
-        final DescribeClusterResult mockDescribeClusterResult = Mockito.mock(DescribeClusterResult.class);
+        final DescribeClusterResult mockDescribeClusterResult = mock(DescribeClusterResult.class);
         when(mockDescribeClusterResult.nodes()).thenReturn(KafkaFuture.completedFuture(nodes));
         when(admin.describeCluster()).thenReturn(mockDescribeClusterResult);
-        DescribeLogDirsResult mockDescribeLogDirsResult = Mockito.mock(DescribeLogDirsResult.class);
+        DescribeLogDirsResult mockDescribeLogDirsResult = mock(DescribeLogDirsResult.class);
         when(mockDescribeLogDirsResult.allDescriptions()).thenReturn(KafkaFuture.completedFuture(descriptions));
         when(admin.describeLogDirs(argThat(integers ->
                 integers.equals(nodes.stream().map(Node::id).collect(Collectors.toSet())))))

--- a/src/test/java/io/strimzi/kafka/quotas/ClusterVolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/ClusterVolumeSourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterVolumeSourceTest {
+
+    private VolumeConsumer volumeConsumer;
+    private ClusterVolumeSource clusterVolumeSource;
+    @Mock
+    private Admin admin;
+
+    @BeforeEach
+    void setUp() {
+        volumeConsumer = new VolumeConsumer();
+        clusterVolumeSource = new ClusterVolumeSource(admin, volumeConsumer);
+        final DescribeClusterResult mockDescribeClusterResult = Mockito.mock(DescribeClusterResult.class);
+        final int nodeId = 1;
+        final Node singleNode = new Node(nodeId, "broker1", 9092);
+        when(mockDescribeClusterResult.nodes()).thenReturn(KafkaFuture.completedFuture(List.of(singleNode)));
+        when(admin.describeCluster()).thenReturn(mockDescribeClusterResult);
+
+        DescribeLogDirsResult mockDescribeLogDirsResult = Mockito.mock(DescribeLogDirsResult.class);
+        final LogDirDescription dirDescription = new LogDirDescription(null, Map.of(), 50, 10);
+        Map<Integer, Map<String, LogDirDescription>> description = Map.of(nodeId, Map.of("dir1", dirDescription));
+        when(mockDescribeLogDirsResult.allDescriptions()).thenReturn(KafkaFuture.completedFuture(description));
+        when(admin.describeLogDirs(Set.of(singleNode.id()))).thenReturn(mockDescribeLogDirsResult);
+    }
+
+    @Test
+    void shouldProduceCollectionOfVolumes() {
+        //Given
+
+        //When
+        clusterVolumeSource.run();
+
+        //Then
+        final List<Collection<Volume>> results = volumeConsumer.getActualResults();
+        Assertions.assertThat(results).hasSize(1);
+        final Collection<Volume> onlyInvocation = results.get(0);
+        Assertions.assertThat(onlyInvocation).containsExactly(new Volume("1", "dir1", 50, 10));
+    }
+
+    private class VolumeConsumer implements Consumer<Collection<Volume>> {
+        private List<Collection<Volume>> actualResults = new ArrayList<>();
+
+        @Override
+        public void accept(Collection<Volume> volumes) {
+            actualResults.add(volumes);
+        }
+
+        public List<Collection<Volume>> getActualResults() {
+            return actualResults;
+        }
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -45,7 +45,7 @@ class StaticQuotaCallbackTest {
     public static final Map<String, Integer> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10);
 
     private static Volume newVolume(int consumedSpace) {
-        return new Volume("-1", "test", 50, consumedSpace);
+        return new Volume("-1", "test", 50, 50 - consumedSpace);
     }
 
     StaticQuotaCallback target;

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -87,7 +87,7 @@ class StaticQuotaCallbackTest {
     void excludedPrincipal() {
         KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "foo");
         target.configure(Map.of(StaticQuotaConfig.EXCLUDED_PRINCIPAL_NAME_LIST_PROP, "foo,bar",
-                                StaticQuotaConfig.PRODUCE_QUOTA_PROP, 1024));
+                StaticQuotaConfig.PRODUCE_QUOTA_PROP, 1024));
         double fooQuotaLimit = target.quotaLimit(ClientQuotaType.PRODUCE, target.quotaMetricTags(ClientQuotaType.PRODUCE, foo, "clientId"));
         assertEquals(Double.MAX_VALUE, fooQuotaLimit);
 

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -23,7 +23,9 @@ import org.apache.kafka.server.quota.ClientQuotaType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class StaticQuotaCallbackTest {
 
     public static final Map<String, Integer> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10);

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaConfigTest.java
@@ -5,64 +5,53 @@
 
 package io.strimzi.kafka.quotas;
 
-import java.util.List;
 import java.util.Map;
 
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.SslConfigs;
-import org.assertj.core.api.Condition;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class StaticQuotaConfigTest {
 
-    public static final String EXPECTED_VALUE = "/ssl/keyStore";
-    public static final String ALTERNATIVE_VALUE = EXPECTED_VALUE + "/random";
+    public static final String ARBITRARY_VALUE = "arbitrary";
 
-    @Test
-    void shouldConfigureMinimalConnectionProperties() {
-        //Given
-        final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = new StaticQuotaConfig.KafkaClientConfig(Map.of(), true);
-
-        //When
-        final Map<String, Object> resolvedClientConfig = kafkaClientConfig.getKafkaClientConfig();
-
-        //Then
-        assertThat(resolvedClientConfig).containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
-        assertThat(resolvedClientConfig).hasEntrySatisfying(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, new Condition<>(o -> {
-            if (o instanceof String) {
-                final String s = (String) o;
-                return s.endsWith(":9091");
-            }
-            return false;
-        }, "Ends with :9091"));
-        assertThat(resolvedClientConfig).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-    }
 
     @ParameterizedTest(name = "shouldResolveListenerProperty: {0}")
-    @MethodSource("sslProperties")
-    void shouldResolveListenerProperty(String property) {
+    @MethodSource("org.apache.kafka.clients.admin.AdminClientConfig#configNames")
+    void shouldResolveAdminConfigurations(String property) {
         //Given
         final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = new StaticQuotaConfig.KafkaClientConfig(
-                Map.of("listener.name.replication-9091." + property, EXPECTED_VALUE,
-                        "listener.name.replication-9092." + property, ALTERNATIVE_VALUE),
+                Map.of("broker.id", "1", "client.quota.callback.kafka.admin." + property, ARBITRARY_VALUE),
                 true);
 
         //When
         final Map<String, Object> resolvedClientConfig = kafkaClientConfig.getKafkaClientConfig();
 
         //Then
-        assertThat(resolvedClientConfig).containsEntry(property, EXPECTED_VALUE);
-        assertThat(resolvedClientConfig).doesNotContainEntry(property, ALTERNATIVE_VALUE);
+        assertThat(resolvedClientConfig).containsEntry(property, ARBITRARY_VALUE);
     }
 
-    public static List<String> sslProperties() {
-        return List.of(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
-                SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
-                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
-                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+    @Test
+    void generateDefaultClientIdWithPrefixIfNoneConfigured() {
+        //Given
+        final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = new StaticQuotaConfig.KafkaClientConfig(
+                Map.of("broker.id", "1"),
+                true);
+
+        //When
+        final Map<String, Object> resolvedClientConfig = kafkaClientConfig.getKafkaClientConfig();
+
+        //Then
+        assertThat(resolvedClientConfig).hasEntrySatisfying(AdminClientConfig.CLIENT_ID_CONFIG, o -> {
+            if (o instanceof String) {
+                assertThat((String) o).startsWith("__strimzi-1-");
+            } else {
+                fail(AdminClientConfig.CLIENT_ID_CONFIG + " was not a string");
+            }
+        });
     }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StaticQuotaConfigTest {
+
+    public static final String EXPECTED_VALUE = "/ssl/keyStore";
+    public static final String ALTERNATIVE_VALUE = EXPECTED_VALUE + "/random";
+
+    @Test
+    void shouldConfigureMinimalConnectionProperties() {
+        //Given
+        final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = new StaticQuotaConfig.KafkaClientConfig(Map.of(), true);
+
+        //When
+        final Map<String, Object> resolvedClientConfig = kafkaClientConfig.getKafkaClientConfig();
+
+        //Then
+        assertThat(resolvedClientConfig).containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+        assertThat(resolvedClientConfig).hasEntrySatisfying(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, new Condition<>(o -> {
+            if (o instanceof String) {
+                final String s = (String) o;
+                return s.endsWith(":9091");
+            }
+            return false;
+        }, "Ends with :9091"));
+        assertThat(resolvedClientConfig).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+    }
+
+    @ParameterizedTest(name = "shouldResolveListenerProperty: {0}")
+    @MethodSource("sslProperties")
+    void shouldResolveListenerProperty(String property) {
+        //Given
+        final StaticQuotaConfig.KafkaClientConfig kafkaClientConfig = new StaticQuotaConfig.KafkaClientConfig(
+                Map.of("listener.name.replication-9091." + property, EXPECTED_VALUE,
+                        "listener.name.replication-9092." + property, ALTERNATIVE_VALUE),
+                true);
+
+        //When
+        final Map<String, Object> resolvedClientConfig = kafkaClientConfig.getKafkaClientConfig();
+
+        //Then
+        assertThat(resolvedClientConfig).containsEntry(property, EXPECTED_VALUE);
+        assertThat(resolvedClientConfig).doesNotContainEntry(property, ALTERNATIVE_VALUE);
+    }
+
+    public static List<String> sslProperties() {
+        return List.of(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+                SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceBuilderTest.java
@@ -7,21 +7,28 @@ package io.strimzi.kafka.quotas;
 
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(MockitoExtension.class)
 class VolumeSourceBuilderTest {
-
 
     private VolumeSourceBuilder volumeSourceBuilder;
 
+    @Mock
+    Admin adminClient;
+
     @BeforeEach
     void setUp() {
-        volumeSourceBuilder = new VolumeSourceBuilder();
+        volumeSourceBuilder = new VolumeSourceBuilder(VolumeSourceBuilder::testForKip827, config -> adminClient);
     }
 
     @AfterEach
@@ -58,7 +65,7 @@ class VolumeSourceBuilderTest {
     @Test
     void shouldReturnClusterVolumeSource() {
         //Given
-        volumeSourceBuilder.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "cluster"), false));
+        volumeSourceBuilder.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "cluster", "bootstrap.servers", "localhost:9091"), false));
 
         //When
         final Runnable configuredRunnable = volumeSourceBuilder.build();
@@ -70,7 +77,7 @@ class VolumeSourceBuilderTest {
     @Test
     void shouldFailClusterModeIfKip827NotAvailable() {
         //Given
-        try (final VolumeSourceBuilder noKip827Factory = new VolumeSourceBuilder(() -> false)) {
+        try (final VolumeSourceBuilder noKip827Factory = new VolumeSourceBuilder(() -> false, config -> adminClient)) {
             noKip827Factory.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "cluster"), false));
             //When
             assertThrows(IllegalStateException.class, noKip827Factory::build);

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceBuilderTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceBuilderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VolumeSourceBuilderTest {
+
+
+    private VolumeSourceBuilder volumeSourceBuilder;
+
+    @BeforeEach
+    void setUp() {
+        volumeSourceBuilder = new VolumeSourceBuilder();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (volumeSourceBuilder != null) {
+            volumeSourceBuilder.close();
+        }
+    }
+
+    @Test
+    void shouldReturnLocalVolumeSourceWhenConfigured() {
+        //Given
+        volumeSourceBuilder.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "local"), false));
+
+        //When
+        final Runnable configuredRunnable = volumeSourceBuilder.build();
+
+        //Then
+        Assertions.assertThat(configuredRunnable).isInstanceOf(StorageChecker.class);
+    }
+
+    @Test
+    void shouldReturnLocalVolumeSourceByDefault() {
+        //Given
+        volumeSourceBuilder.withConfig(new StaticQuotaConfig(Map.of(), false));
+
+        //When
+        final Runnable configuredRunnable = volumeSourceBuilder.build();
+
+        //Then
+        Assertions.assertThat(configuredRunnable).isInstanceOf(StorageChecker.class);
+    }
+
+    @Test
+    void shouldReturnClusterVolumeSource() {
+        //Given
+        volumeSourceBuilder.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "cluster"), false));
+
+        //When
+        final Runnable configuredRunnable = volumeSourceBuilder.build();
+
+        //Then
+        Assertions.assertThat(configuredRunnable).isInstanceOf(ClusterVolumeSource.class);
+    }
+
+    @Test
+    void shouldFailClusterModeIfKip827NotAvailable() {
+        //Given
+        try (final VolumeSourceBuilder noKip827Factory = new VolumeSourceBuilder(() -> false)) {
+            noKip827Factory.withConfig(new StaticQuotaConfig(Map.of(StaticQuotaConfig.VOLUME_SOURCE_PROP, "cluster"), false));
+            //When
+            assertThrows(IllegalStateException.class, noKip827Factory::build);
+        }
+        //Then
+    }
+}


### PR DESCRIPTION
This PR represents the basic support for using KIP-827 within the quota plug-in. 

To keep the size of the pull request more manageable this PR deliberately ignores several edge cases around handling issues with connectivity and consistency between API calls. We will to follow up with additional Pull Request(s) to address the error handling.  

We will also follow up with additional PR's to address the extension points mentioned in https://github.com/strimzi/proposals/pull/67. While important improvements to the plug-in they are not essential to adding KIP-827 support and would just obscure the body of this change.  

~This change also (at least in part) fixes https://github.com/strimzi/kafka-quotas-plugin/issues/2. In part because it still defaults to the problematic implementation of summing all used bytes and comparing to a global value.~
We didn't actually fix#2 in this PR, that is still on the todo list.

Part of https://github.com/strimzi/proposals/pull/67 and https://github.com/strimzi/kafka-quotas-plugin/issues/28