### PR TITLE
Add Java 17 pipeline for testing

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -20,9 +20,13 @@ jobs:
     strategy:
       matrix:
         'java-11':
-          image: 'Ubuntu-18.04'
+          image: 'Ubuntu-20.04'
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        'java-17':
+          image: 'Ubuntu-20.04'
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
@@ -36,7 +40,7 @@ jobs:
     steps:
       - task: Cache@2
         inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
+          key: 'mvn-m2-cache | $(System.JobName) | pom.xml'
           path: "$(MVN_CACHE_FOLDER)"
         displayName: Maven cache
       - template: 'templates/setup_java.yaml'

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -4,6 +4,14 @@ set -e
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
+# The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
+JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+if [ "${JAVA_MAJOR_VERSION}" -eq "11" ] ; then
+  # some parts of the workflow should be done only one on the main build which is currently Java 11
+  export MAIN_BUILD="TRUE"
+  echo "Running main build"
+fi
+
 # Build with Maven
 mvn $MVN_ARGS install
 mvn $MVN_ARGS spotbugs:check
@@ -14,6 +22,8 @@ if [ "$BUILD_REASON" == "PullRequest" ] ; then
 elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/main" ]; then
     echo "Not in main branch or in release tag - nothing to push"
 else
-    echo "In main branch or in release tag - pushing to nexus"
-    ./.azure/scripts/push-to-nexus.sh
+    if [ "${MAIN_BUILD}" = "TRUE" ] ; then
+        echo "In main branch or in release tag - pushing to nexus"
+        ./.azure/scripts/push-to-nexus.sh
+    fi
 fi

--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -23,6 +23,17 @@ steps:
   condition: eq(variables['JDK_VERSION'], '11')
 
 - bash: |
+    sudo apt-get install openjdk-17-jdk
+  displayName: 'Install openjdk17'
+  condition: eq(variables['JDK_VERSION'], '17')
+
+- bash: |
+    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+    echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+  displayName: 'Setup JAVA_VERSION=17'
+  condition: eq(variables['JDK_VERSION'], '17')
+
+- bash: |
     echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
     echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"
     echo "##vso[task.setvariable variable=PATH]$(jdk_path)/bin:$(PATH)"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,10 +38,11 @@ jobs:
       uses: actions/checkout@v2
     
     # Setup OpenJDK 11
-    - name: Setup java
-      uses: joschi/setup-jdk@v2
+    - uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/pom.xml
+++ b/pom.xml
@@ -77,20 +77,24 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.version>3.8.1</maven.compiler.version>
-        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
-        <maven.assembly.version>3.1.0</maven.assembly.version>
+
+        <maven.compiler.version>3.10.1</maven.compiler.version>
+        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <maven.assembly.version>3.4.2</maven.assembly.version>
         <maven.shade.version>3.1.0</maven.shade.version>
-        <maven.javadoc.version>3.1.0</maven.javadoc.version>
+        <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.source.version>3.0.1</maven.source.version>
-        <maven.dependency.version>3.1.1</maven.dependency.version>
+        <maven.dependency.version>3.3.0</maven.dependency.version>
         <maven.gpg.version>1.6</maven.gpg.version>
-        <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
-        <spotbugs.version>4.0.3</spotbugs.version>
+        <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
+        <checkstyle.version>9.2.1</checkstyle.version>
+        <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
+        <spotbugs.version>4.7.2</spotbugs.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
+        <maven.enforced.version>3.0.0-M2</maven.enforced.version>
 
         <kafka.version>3.0.0</kafka.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -176,16 +180,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven.dependency.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- Override dep to support Java 11,
-                                 can remove this once maven.dependency.version >= 3.1.2
-                                 see https://issues.apache.org/jira/browse/MDEP-613 -->
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.1</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <id>copy-dependencies</id>
@@ -234,7 +228,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
+                        <version>${checkstyle.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -298,7 +292,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.0</version><dependencies>
+                <version>${maven.spotbugs.version}</version><dependencies>
                 <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
                 <dependency>
                     <groupId>com.github.spotbugs</groupId>
@@ -383,7 +377,7 @@
                 <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>${maven.enforced.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-banned-dependencies</id>

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -53,6 +53,9 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
 
     private final ScheduledExecutorService backgroundScheduler;
 
+    /**
+     * Constructs the Static Quota Callback class
+     */
     public StaticQuotaCallback() {
         this(new StorageChecker(), Executors.newSingleThreadScheduledExecutor(r -> {
             final Thread thread = new Thread(r, StaticQuotaCallback.class.getSimpleName() + "-taskExecutor");


### PR DESCRIPTION
This PR adds Java 17 support to the build pipeline. It does the following changes:
* Adds new pipeline with Java 17 to test the build and run the tests on it as well
* Updates the versions of some Maven plugins and used properties to configure them
* Updates the build script to push to Nexus only from Java 11
* Updates the CodeQL GitHub action to use undeprecated way to setup Java
* Fixes the Javadocs to be compatible with Java 17