### PR TITLE
Add available ratio limit type

### DIFF
--- a/src/main/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicy.java
+++ b/src/main/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Determines if the available ratio on any given volume falls below the configured limit.
+ */
+public class AvailableRatioThrottleFactorPolicy extends PerVolumeThrottleFactorPolicy {
+
+    private static final Logger log = LoggerFactory.getLogger(AvailableRatioThrottleFactorPolicy.class);
+
+    private final double availableBytesRatio;
+
+    /**
+     * Creates and configures the throttle factor supplier
+     *
+     * @param availableBytesRatio the minimum volume available ratio below which the throttle should be applied.
+     */
+    public AvailableRatioThrottleFactorPolicy(double availableBytesRatio) {
+        this.availableBytesRatio = availableBytesRatio;
+    }
+
+    @Override
+    boolean shouldThrottle(VolumeUsage volume) {
+        boolean shouldThrottle = volume.getAvailableRatio() <= availableBytesRatio;
+        if (shouldThrottle) {
+            log.debug("A volume containing logDir {} on broker {} has available ratio of {}, below the limit of {}", volume.getLogDir(), volume.getBrokerId(), volume.getAvailableBytes(), availableBytesRatio);
+        }
+        return shouldThrottle;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/quotas/PerVolumeThrottleFactorPolicy.java
+++ b/src/main/java/io/strimzi/kafka/quotas/PerVolumeThrottleFactorPolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.quotas;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Base Policy for limit types where we want a circuit-breaker type behaviour, throttling to a zero factor
+ * if <em>any</em> volume satisfies a predicate. For example:
+ * <ul>
+ *     <li>Throttle to zero if any volume in the cluster is greater than 80% full</li>
+ *     <li>Throttle to zero if any volume with logdir named /tmp has less than 1G available space</li>
+ * </ul>
+ */
+abstract class PerVolumeThrottleFactorPolicy implements ThrottleFactorPolicy {
+
+    abstract boolean shouldThrottle(VolumeUsage usage);
+
+    @Override
+    public double calculateFactor(Collection<VolumeUsage> observedVolumes) {
+        Optional<VolumeUsage> anyViolation = observedVolumes.stream().filter(this::shouldThrottle).findAny();
+        return anyViolation.isPresent() ? 0.0d : 1.0d;
+    }
+
+}

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeUsage.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeUsage.java
@@ -69,6 +69,17 @@ public class VolumeUsage {
         return capacity - availableBytes;
     }
 
+    /**
+     *
+     * @return The ratio of available bytes to capacity bytes (0.0 if capacity is 0 bytes).
+     */
+    public double getAvailableRatio() {
+        if (capacity == 0) {
+            return 0;
+        }
+        return (double) availableBytes / capacity;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class AvailableRatioThrottleFactorPolicyTest {
+    private static final Offset<Double> OFFSET = Offset.offset(0.00001d);
+
+    private AvailableRatioThrottleFactorPolicy availableBytesThrottleFactorSupplier;
+
+    @BeforeEach
+    void setUp() {
+        availableBytesThrottleFactorSupplier = new AvailableRatioThrottleFactorPolicy(0.1d);
+    }
+
+    @Test
+    void shouldNotThrottleIfHasAvailableBytesAboveLimit() {
+        //Given
+
+        //When
+        final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.11)));
+
+        //Then
+        assertThat(actualFactor).isCloseTo(1.0d, OFFSET);
+    }
+
+    @Test
+    void shouldThrottleIfHasAvailableBytesAtLimit() {
+        //Given
+
+        //When
+        final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.1)));
+
+        //Then
+        assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
+    }
+
+
+    @Test
+    void shouldThrottleIfHasAvailableRatioBelowLimit() {
+        //Given
+
+        //When
+        final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.09)));
+
+        //Then
+        assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
+    }
+
+    @Test
+    void shouldThrottleIfAnyVolumeHasAvailableRatioBelowLimit() {
+        //Given
+
+        //When
+        final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.5),
+                volumeWithAvailableRatio(0.1)));
+
+        //Then
+        assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
+    }
+
+    @Test
+    void shouldThrottleIfAnyVolumeHasZeroCapacity() {
+        //Given
+
+        //When
+        long capacity = 0L;
+        final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.5),
+                new VolumeUsage("0", "/var/lib/data", capacity, 100)));
+
+        //Then
+        assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
+    }
+
+    private static VolumeUsage volumeWithAvailableRatio(double availableRatio) {
+        int available = 100;
+        return new VolumeUsage("0", "/var/lib/data", (long) (available / availableRatio), available);
+    }
+}


### PR DESCRIPTION
Enables users to throttle the produce quota when the availableRatio (availableBytes/totalBytes) is less than or equal to a threshold.

The new configuration property is:
`client.quota.callback.static.storage.per.volume.limit.min.available.ratio`

Which accepts a double between 0 and 1 inclusive

Why:
It may be convenient to be able to throttle message production when any volume's usage ratio drops below a threshold. This means you could have a single configuration for heterogeneous disks saying cease all message production if any volume's available ratio is below 0.01

See Also:
* https://github.com/strimzi/proposals/blob/main/047-cluster-wide-volume-usage-quota-management.md
* [Add min available bytes storage policy](https://github.com/strimzi/kafka-quotas-plugin/pull/33)