### PR TITLE
Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ The plugin currently provides the following metrics:
 * `io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=Fetch` shows the currently configured fetch quota
 * `io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=Request` shows the currently configured request quota
 
+### Additional metrics for cluster wide monitoring
+
+| Name                          | Metric Type | Meaning                                                                        | Type           | Tags                                          |
+|-------------------------------|-------------|--------------------------------------------------------------------------------|----------------|-----------------------------------------------|
+| ThrottleFactor                | Gauge       | The current factor applied by the plug-in [0..1]                               | ThrottleFactor | `observingBrokerId`                           |
+| FallbackThrottleFactorApplied | Counter     | The number of times the plug-in has transitioned to using the fall back factor | ThrottleFactor | `observingBrokerId`                           |
+| LimitViolated                 | Counter     | A count of the number `logDir`s which violate the configured limit             | ThrottleFactor | `observingBrokerId`                           |
+| ActiveBrokers                 | Gauge       | The current number of brokers returned by the describeCluster rpc              | VolumeSource   | `observingBrokerId`                           |
+| ActiveLogDirs                 | Gauge       | The number of logDirs returned by the describeLogDirs RPC                      | VolumeSource   | `observingBrokerId`                           | 
+| AvailableBytes                | Gauge       | The number of available bytes returned by the describeLogDirs RPC              | VolumeSource   | `[observingBrokerId, remoteBrokerId, logDir]` |
+| ConsumedBytes                 | Gauge       | The number of consumed bytes returned by the describeLogDirs RPC               | VolumeSource   | `[observingBrokerId, remoteBrokerId, logDir]` |
+
+### Tag definitions
+| Tag               | Definition                                                             |
+|-------------------|------------------------------------------------------------------------|
+| observingBrokerId | The BrokerId of the broker node executing the plug-in                  |
+| remoteBrokerId    | The BrokerId of the broker node hosting the logDir                     |
+| logDir            | The path to the specific logDir as returned by the describeLogDirs RPC |
+
 ## Building
 
 To build the plugin:

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -209,7 +209,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     }
 
     /**
-     * Generate an mBean metric name
+     * Generate a Yammer metric name
      * @param name  the name of the Metric.
      * @param type  the type to which the Metric belongs.
      * @param group the group to which the Metric belongs type
@@ -221,7 +221,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     }
 
     /**
-     * Generate an mBean metric name
+     * Generate a Yammer metric name
      * @param name  the name of the Metric.
      * @param type  the type to which the Metric belongs.
      * @param group the group to which the Metric belongs type

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -248,11 +248,15 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     }
 
     private static String sanitise(String name) {
+        // It would be more efficient to create a single pattern and replace everything once.
+        // However, I think this makes things clearer and easier to understand.
         return name.replaceAll(":", "")
                 .replaceAll("\\?", "")
                 .replaceAll("\\*", "")
                 .replaceAll("//", "")
-                .replaceAll("\\$$", "");
+                .replaceAll("\\$$", "")
+                .replaceAll("=", "")
+                .replaceAll(",", "");
     }
 
     private static class ClientQuotaGauge extends Gauge<Double> {

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -148,7 +148,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         long storageCheckInterval = config.getStorageCheckInterval();
         if (storageCheckInterval > 0L) {
             LinkedHashMap<String, String> defaultTags = new LinkedHashMap<>();
-            defaultTags.put("observingBrokerId", config.getBrokerId());
+            defaultTags.put(HOST_BROKER_TAG, config.getBrokerId());
 
             final Optional<Long> availableBytesLimitConfig = config.getAvailableBytesLimit();
             final Optional<Double> availableRatioLimit = config.getAvailableRatioLimit();

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -248,7 +248,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
     }
 
     /**
-     * MetricNames are translated to mbean names which need to comply with the @see javax.management.ObjectName rules.
+     * MetricNames are translated to mbean names which need to comply with the @link{<a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.management/javax/management/ObjectName.html">javax.management.ObjectName</a>} rules.
      * Unfortunately the constructors we use from Yammer don't validate the metric names, so we do it ourselves.
      *
      * @param name value to be sanitised

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -247,16 +247,19 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         return new MetricName(sanitisedGroup, sanitisedType, sanitisedName, SCOPE, mBeanName);
     }
 
+    /**
+     * MetricNames are translated to mbean names which need to comply with the @see javax.management.ObjectName rules.
+     * Unfortunately the constructors we use from Yammer don't validate the metric names, so we do it ourselves.
+     *
+     * @param name value to be sanitised
+     * @return the value with all illegal characters removed
+     */
     private static String sanitise(String name) {
         // It would be more efficient to create a single pattern and replace everything once.
         // However, I think this makes things clearer and easier to understand.
-        return name.replaceAll(":", "")
-                .replaceAll("\\?", "")
-                .replaceAll("\\*", "")
-                .replaceAll("//", "")
-                .replaceAll("\\$$", "")
-                .replaceAll("=", "")
-                .replaceAll(",", "");
+        return name.replaceAll("[:?*=,]", "")
+                .replaceAll("//", "") // Double slashes are reserved as a protocol specifier
+                .replaceAll("\\$$", ""); // $ is only illegal as a trailing character as it is used to denote inner classes.
     }
 
     private static class ClientQuotaGauge extends Gauge<Double> {

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -159,6 +159,16 @@ public class StaticQuotaConfig extends AbstractConfig {
         }, () -> "Should be a valid iso8601 duration string like PT5M");
     }
 
+    /**
+     * Get the broker id of the current broker.
+     * @return the specified broker id or -1 if not defined.
+     */
+    public String getBrokerId() {
+        //Arguably in-efficient to look up the sys prop if we don't need it, but it reads better and is invoked rarely
+        final String brokerIdFromSysProps = System.getProperty("broker.id", "-1");
+        return this.originalsStrings().getOrDefault("broker.id", brokerIdFromSysProps);
+    }
+
 
     static class KafkaClientConfig extends AbstractConfig {
         public static final String CLIENT_ID_PREFIX_PROP = CLIENT_QUOTA_CALLBACK_STATIC_PREFIX + ".kafka.clientIdPrefix";

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -161,14 +161,11 @@ public class StaticQuotaConfig extends AbstractConfig {
 
     /**
      * Get the broker id of the current broker.
-     * @return the specified broker id or -1 if not defined.
+     * @return the specified broker id.
      */
     public String getBrokerId() {
-        //Arguably in-efficient to look up the sys prop if we don't need it, but it reads better and is invoked rarely
-        final String brokerIdFromSysProps = System.getProperty("broker.id", "-1");
-        return this.originalsStrings().getOrDefault("broker.id", brokerIdFromSysProps);
+        return this.getString("broker.id");
     }
-
 
     static class KafkaClientConfig extends AbstractConfig {
         public static final String CLIENT_ID_PREFIX_PROP = CLIENT_QUOTA_CALLBACK_STATIC_PREFIX + ".kafka.clientIdPrefix";

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaConfig.java
@@ -164,7 +164,7 @@ public class StaticQuotaConfig extends AbstractConfig {
      * @return the specified broker id.
      */
     public String getBrokerId() {
-        return this.getString("broker.id");
+        return this.originalsStrings().get("broker.id");
     }
 
     static class KafkaClientConfig extends AbstractConfig {

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -180,10 +180,10 @@ public class VolumeSource implements Runnable {
 
         volumeUsages.forEach(volumeUsage -> {
             availableBytesGauges.get(volumeUsage.getBrokerId())
-                    .computeIfAbsent(volumeUsage.getLogDir(), buildCounter(volumeUsage, "available_bytes"))
+                    .computeIfAbsent(volumeUsage.getLogDir(), buildCounter(volumeUsage, "AvailableBytes"))
                     .set(volumeUsage.getAvailableBytes());
             consumedBytesGauges.get(volumeUsage.getBrokerId())
-                    .computeIfAbsent(volumeUsage.getLogDir(), buildCounter(volumeUsage, "consumed_bytes"))
+                    .computeIfAbsent(volumeUsage.getLogDir(), buildCounter(volumeUsage, "ConsumedBytes"))
                     .set(volumeUsage.getConsumedSpace());
         });
         return success(volumeUsages);

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -271,6 +271,11 @@ public class VolumeSource implements Runnable {
         }
     }
 
+    /**
+     * Arguably using AtomicLong here is over kill (we just need volatile semantics) however it makes sense to
+     * standardise on a single gauge type, and we need to use AtomicLongs for the available and consumed bytes gauges
+     * as they are stored in maps (to ensure the correct tagging of the metrics)
+     */
     private static class AtomicLongGauge extends Gauge<Long> {
 
         private final AtomicLong atomicLong;

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -81,7 +81,7 @@ public class VolumeSource implements Runnable {
      * @param timeoutUnit    What unit is the timeout configured in
      * @param defaultTags    The minimum collection of tags to add each metric.
      */
-    @SuppressFBWarnings("EI_EXPOSE_REP2") //Injecting the dependency is the right move as it can be shared
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Injecting the dependency is the right move as it can be shared")
     public VolumeSource(Admin admin, VolumeObserver volumeObserver, int timeout, TimeUnit timeoutUnit, LinkedHashMap<String, String> defaultTags) {
         this.volumeObserver = volumeObserver;
         this.admin = admin;

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
@@ -67,13 +67,15 @@ public class VolumeSourceBuilder implements AutoCloseable {
         adminClient = adminClientFactory.apply(config.getKafkaClientConfig());
         //Timeout just before the next job will be scheduled to run to avoid tasks queuing on the client thread pool.
         final int timeout = config.getStorageCheckInterval() - 1;
-        return new VolumeSource(adminClient, volumeObserver, timeout, TimeUnit.SECONDS);
+        final String localBrokerId = this.config.getBrokerId();
+        return new VolumeSource(localBrokerId, adminClient, volumeObserver, timeout, TimeUnit.SECONDS);
     }
-
     @Override
     public void close() {
         if (adminClient != null) {
             adminClient.close();
         }
     }
+
+
 }

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSourceBuilder.java
@@ -67,6 +67,7 @@ public class VolumeSourceBuilder implements AutoCloseable {
      * @param defaultTags A linked hash map (for deterministic order) of key value pairs to add to each metric
      * @return this to allow fluent usage of the builder.
      */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "The tags are defensively copied at metric creation time to allow the defaults to be updated")
     public VolumeSourceBuilder withDefaultTags(LinkedHashMap<String, String> defaultTags) {
         this.defaultTags = defaultTags;
         return this;

--- a/src/test/java/io/strimzi/kafka/quotas/AvailableBytesThrottleFactorPolicyTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/AvailableBytesThrottleFactorPolicyTest.java
@@ -5,6 +5,11 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.util.List;
+import java.util.SortedMap;
+
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
 import io.strimzi.kafka.quotas.throttle.AvailableBytesThrottleFactorPolicy;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-
+import static io.strimzi.kafka.quotas.MetricUtils.METRICS_SCOPE;
+import static io.strimzi.kafka.quotas.MetricUtils.getMetricGroup;
+import static io.strimzi.kafka.quotas.MetricUtils.resetMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,11 +27,13 @@ class AvailableBytesThrottleFactorPolicyTest {
 
     private static final long AVAILABLE_BYTES_LIMIT = 100L;
     private static final Offset<Double> OFFSET = Offset.offset(0.00001d);
+    private static final String METRICS_TYPE = "ThrottleFactor";
 
     private AvailableBytesThrottleFactorPolicy availableBytesThrottleFactorSupplier;
 
     @BeforeEach
     void setUp() {
+        resetMetrics(METRICS_SCOPE, METRICS_TYPE);
         availableBytesThrottleFactorSupplier = new AvailableBytesThrottleFactorPolicy(AVAILABLE_BYTES_LIMIT);
     }
 
@@ -73,6 +81,30 @@ class AvailableBytesThrottleFactorPolicyTest {
 
         //Then
         assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
+    }
+
+    @Test
+    void shouldNotIncrementViolationCounterWhenAllVolumesAreAboveTheLimit() {
+        //Given
+
+        //When
+        availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableBytes(1000L)));
+
+        //Then
+        final SortedMap<MetricName, Metric> metricGroup = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        MetricUtils.assertCounterMetric(metricGroup, "LimitViolated", 0L);
+    }
+
+    @Test
+    void shouldIncrementViolationCounterWhenAllVolumesAreBelowTheLimit() {
+        //Given
+
+        //When
+        availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableBytes(AVAILABLE_BYTES_LIMIT + 1)));
+
+        //Then
+        final SortedMap<MetricName, Metric> metricGroup = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        MetricUtils.assertCounterMetric(metricGroup, "LimitViolated", 0L);
     }
 
     private static VolumeUsage volumeWithAvailableBytes(long availableBytes) {

--- a/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
+++ b/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
@@ -6,11 +6,13 @@
 package io.strimzi.kafka.quotas;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
 import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricName;
@@ -19,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetricUtils {
+    public static final String METRICS_SCOPE = "io.strimzi.kafka.quotas.StaticQuotaCallback";
+
     /**
      * Static utilities DO NOT instantiate.
      */
@@ -26,7 +30,7 @@ public class MetricUtils {
     }
 
     public static SortedMap<MetricName, Metric> getMetricGroup(String scope, String type) {
-        SortedMap<String, SortedMap<MetricName, Metric>> storageMetrics = Metrics.defaultRegistry().groupedMetrics((name, metric) -> scope.equals(name.getScope()) && type.equals(name.getType()));
+        SortedMap<String, SortedMap<MetricName, Metric>> storageMetrics = getGroupedMetrics(scope, type);
         assertEquals(1, storageMetrics.size(), "unexpected number of metrics in group");
         return storageMetrics.entrySet().iterator().next().getValue();
     }
@@ -35,16 +39,36 @@ public class MetricUtils {
         assertGaugeMetric(metrics, name, null, expected);
     }
 
-    public static <T> void assertGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, LinkedHashMap<String, String> tags, T expected) {
-        final String expectedTags = tags != null ? tags.entrySet().stream().map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue())).collect(Collectors.joining(",")) : null;
-        Optional<Gauge<T>> desired = findGaugeMetric(metrics, name, expectedTags);
-        assertTrue(desired.isPresent(), String.format("metric with name %s with tags: %s not found in %s", name, expectedTags, metrics));
-        Gauge<T> gauge = desired.get();
-        assertEquals(expected, gauge.value(), String.format("metric %s has unexpected value", name));
+    public static void assertCounterMetric(SortedMap<MetricName, Metric> metrics, String name, long expected) {
+        assertCounterMetric(metrics, name, null, expected);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> Optional<Gauge<T>> findGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, String expectedTags) {
+    public static <T> void assertGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, LinkedHashMap<String, String> tags, T expected) {
+        final String expectedTags = tags != null ? tags.entrySet().stream().map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue())).collect(Collectors.joining(",")) : null;
+        Optional<Metric> desired = findGaugeMetric(metrics, name, expectedTags);
+        assertTrue(desired.isPresent(), String.format("metric with name %s with tags: %s not found in %s", name, expectedTags, metrics));
+        Gauge<T> gauge = (Gauge<T>) desired.get();
+        assertEquals(expected, gauge.value(), String.format("metric %s has unexpected value", name));
+    }
+
+    public static void assertCounterMetric(SortedMap<MetricName, Metric> metrics, String name, LinkedHashMap<String, String> tags, long expected) {
+        final String expectedTags = tags != null ? tags.entrySet().stream().map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue())).collect(Collectors.joining(",")) : null;
+        Optional<Metric> desired = findCounterMetric(metrics, name, expectedTags);
+        assertTrue(desired.isPresent(), String.format("metric with name %s with tags: %s not found in %s", name, expectedTags, metrics));
+        Counter counter = (Counter) desired.get();
+        assertEquals(expected, counter.count(), String.format("metric %s has unexpected value", name));
+    }
+
+    public static Optional<Metric> findGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, String expectedTags) {
+        return findMetric(metrics, name, expectedTags, Gauge.class);
+    }
+
+    public static Optional<Metric> findCounterMetric(SortedMap<MetricName, Metric> metrics, String name, String expectedTags) {
+        return findMetric(metrics, name, expectedTags, Counter.class);
+    }
+
+    public static <T extends Metric> Optional<Metric> findMetric(SortedMap<MetricName, Metric> metrics, String name, String expectedTags, Class<T> metricType) {
         return metrics.entrySet().stream().filter(e -> {
             final MetricName metricName = e.getKey();
             if (name.equals(metricName.getName())) {
@@ -52,12 +76,26 @@ public class MetricUtils {
             } else {
                 return false;
             }
-        }).map(e -> (Gauge<T>) e.getValue()).findFirst();
+        })
+        .filter(entry -> metricType.isInstance(entry.getValue()))
+        .map(Map.Entry::getValue)
+        .findFirst();
+    }
+
+    public static void resetMetrics(String scope, String type) {
+        final SortedMap<String, SortedMap<MetricName, Metric>> groupedMetrics = getGroupedMetrics(scope, type);
+        groupedMetrics.values()
+                .forEach(innerMap ->
+                        innerMap.forEach((metricName, metric) -> Metrics.defaultRegistry().removeMetric(metricName)));
     }
 
     private static String extractTags(String name, MetricName metricName) {
         final String mBeanName = metricName.getMBeanName();
         final int nameIndex = mBeanName.lastIndexOf(name);
         return mBeanName.substring(nameIndex + name.length() + 1);
+    }
+
+    private static SortedMap<String, SortedMap<MetricName, Metric>> getGroupedMetrics(String scope, String type) {
+        return Metrics.defaultRegistry().groupedMetrics((name, metric) -> scope.equals(name.getScope()) && type.equals(name.getType()));
     }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
+++ b/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
@@ -92,7 +92,11 @@ public class MetricUtils {
     private static String extractTags(String name, MetricName metricName) {
         final String mBeanName = metricName.getMBeanName();
         final int nameIndex = mBeanName.lastIndexOf(name);
-        return mBeanName.substring(nameIndex + name.length() + 1);
+        if (mBeanName.length() <= nameIndex + name.length() + 1) {
+            return "";
+        } else {
+            return mBeanName.substring(nameIndex + name.length() + 1);
+        }
     }
 
     private static SortedMap<String, SortedMap<MetricName, Metric>> getGroupedMetrics(String scope, String type) {

--- a/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
+++ b/src/test/java/io/strimzi/kafka/quotas/MetricUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.util.Optional;
+import java.util.SortedMap;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MetricUtils {
+    /**
+     * Static utilities DO NOT instantiate.
+     */
+    private MetricUtils() {
+    }
+
+    public static SortedMap<MetricName, Metric> getMetricGroup(String scope, String type) {
+        SortedMap<String, SortedMap<MetricName, Metric>> storageMetrics = Metrics.defaultRegistry().groupedMetrics((name, metric) -> scope.equals(name.getScope()) && type.equals(name.getType()));
+        assertEquals(1, storageMetrics.size(), "unexpected number of metrics in group");
+        return storageMetrics.entrySet().iterator().next().getValue();
+    }
+
+    public static <T> void assertGaugeMetric(SortedMap<MetricName, Metric> metrics, String name, T expected) {
+        Optional<Gauge<T>> desired = findGaugeMetric(metrics, name);
+        assertTrue(desired.isPresent(), String.format("metric with name %s not found in %s", name, metrics));
+        Gauge<T> gauge = desired.get();
+        assertEquals(expected, gauge.value(), String.format("metric %s has unexpected value", name));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<Gauge<T>> findGaugeMetric(SortedMap<MetricName, Metric> metrics, String name) {
+        return metrics.entrySet().stream().filter(e -> name.equals(e.getKey().getName())).map(e -> (Gauge<T>) e.getValue()).findFirst();
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -49,7 +49,9 @@ import static org.mockito.Mockito.when;
 class StaticQuotaCallbackTest {
 
     private static final int STORAGE_CHECK_INTERVAL = 20;
-    private static final Map<String, Object> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, String.valueOf(STORAGE_CHECK_INTERVAL), StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", StaticQuotaConfig.AVAILABLE_BYTES_PROP, "2");
+    private static final String BROKER_ID_PROPERTY = "broker.id";
+    private static final String BROKER_ID = "1";
+    private static final Map<String, Object> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, String.valueOf(STORAGE_CHECK_INTERVAL), StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", StaticQuotaConfig.AVAILABLE_BYTES_PROP, "2", BROKER_ID_PROPERTY, BROKER_ID);
     private static final long VOLUME_CAPACITY = 50;
     public static final long THROTTLE_FACTOR_EXPIRY_INTERVAL = 10L;
     private static final String METRICS_TYPE = "StaticQuotaCallback";
@@ -83,7 +85,7 @@ class StaticQuotaCallbackTest {
     @Test
     void quotaDefaults() {
         KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "foo");
-        target.configure(Map.of(StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"));
+        target.configure(Map.of(StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", BROKER_ID_PROPERTY, BROKER_ID));
 
         double produceQuotaLimit = target.quotaLimit(ClientQuotaType.PRODUCE, target.quotaMetricTags(ClientQuotaType.PRODUCE, foo, "clientId"));
         assertEquals(Double.MAX_VALUE, produceQuotaLimit);
@@ -96,7 +98,8 @@ class StaticQuotaCallbackTest {
     void produceQuota() {
         KafkaPrincipal foo = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "foo");
         target.configure(Map.of(StaticQuotaConfig.PRODUCE_QUOTA_PROP, 1024,
-                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"));
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092",
+                BROKER_ID_PROPERTY, BROKER_ID_PROPERTY));
 
         double quotaLimit = target.quotaLimit(ClientQuotaType.PRODUCE, target.quotaMetricTags(ClientQuotaType.PRODUCE, foo, "clientId"));
         assertEquals(1024, quotaLimit);
@@ -113,7 +116,8 @@ class StaticQuotaCallbackTest {
         quotaCallback.configure(Map.of(
                 StaticQuotaConfig.AVAILABLE_BYTES_PROP, "15",
                 StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
-                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092",
+                BROKER_ID_PROPERTY, BROKER_ID_PROPERTY
         ));
 
         //When
@@ -135,7 +139,8 @@ class StaticQuotaCallbackTest {
         quotaCallback.configure(Map.of(
                 StaticQuotaConfig.AVAILABLE_RATIO_PROP, "0.5",
                 StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
-                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092",
+                BROKER_ID_PROPERTY, BROKER_ID_PROPERTY
         ));
 
         //When
@@ -159,7 +164,8 @@ class StaticQuotaCallbackTest {
                 StaticQuotaConfig.AVAILABLE_RATIO_PROP, "0.5",
                 StaticQuotaConfig.AVAILABLE_BYTES_PROP, "1",
                 StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
-                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092",
+                BROKER_ID_PROPERTY, BROKER_ID_PROPERTY
         )));
     }
 
@@ -211,7 +217,7 @@ class StaticQuotaCallbackTest {
         StaticQuotaCallback target = new StaticQuotaCallback(volumeSourceBuilder, scheduledExecutorService);
 
         //When
-        target.configure(Map.of(StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"));
+        target.configure(Map.of(StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", BROKER_ID_PROPERTY, BROKER_ID));
 
         //Then
         verify(scheduledExecutorService, times(0)).scheduleWithFixedDelay(any(), anyLong(), anyLong(), any(TimeUnit.class));

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -147,14 +147,12 @@ class StaticQuotaCallbackTest {
         StaticQuotaCallback quotaCallback = new StaticQuotaCallback(volumeSourceBuilder, backgroundScheduler);
 
         //Then
-        assertThrows(IllegalStateException.class, () -> {
-            quotaCallback.configure(Map.of(
-                    StaticQuotaConfig.AVAILABLE_RATIO_PROP, 0.5,
-                    StaticQuotaConfig.AVAILABLE_BYTES_PROP, 1,
-                    StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10,
-                    StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
-            ));
-        });
+        assertThrows(IllegalStateException.class, () -> quotaCallback.configure(Map.of(
+                StaticQuotaConfig.AVAILABLE_RATIO_PROP, 0.5,
+                StaticQuotaConfig.AVAILABLE_BYTES_PROP, 1,
+                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10,
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
+        )));
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -300,7 +300,7 @@ class StaticQuotaCallbackTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenGroupContains(String name, String illegalPattern) {
         //Given
 
@@ -313,7 +313,7 @@ class StaticQuotaCallbackTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenTypeContains(String name, String illegalPattern) {
         //Given
 
@@ -326,7 +326,7 @@ class StaticQuotaCallbackTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenTypeClassContains(String name, String illegalPattern) {
         //Given
 
@@ -338,9 +338,8 @@ class StaticQuotaCallbackTest {
         assertNameComponentIsValid(metricName.getMBeanName());
     }
 
-
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenGroupContainsWithTags(String name, String illegalPattern) {
         //Given
 
@@ -353,7 +352,7 @@ class StaticQuotaCallbackTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenTypeContainsWithTags(String name, String illegalPattern) {
         //Given
 
@@ -366,7 +365,7 @@ class StaticQuotaCallbackTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?",  "comma,','", "equals,="})
     void shouldProduceValidMbeanObjectNamesWhenTypeClassContainsWithTags(String name, String illegalPattern) {
         //Given
 

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 class StaticQuotaCallbackTest {
 
     private static final int STORAGE_CHECK_INTERVAL = 20;
-    private static final Map<String, Object> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, STORAGE_CHECK_INTERVAL, StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", StaticQuotaConfig.AVAILABLE_BYTES_PROP, "2");
+    private static final Map<String, Object> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, String.valueOf(STORAGE_CHECK_INTERVAL), StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", StaticQuotaConfig.AVAILABLE_BYTES_PROP, "2");
     private static final long VOLUME_CAPACITY = 50;
     public static final long THROTTLE_FACTOR_EXPIRY_INTERVAL = 10L;
 
@@ -64,6 +64,7 @@ class StaticQuotaCallbackTest {
         target = new StaticQuotaCallback();
         when(volumeSourceBuilder.withConfig(any())).thenReturn(volumeSourceBuilder);
         when(volumeSourceBuilder.withVolumeObserver(any())).thenReturn(volumeSourceBuilder);
+        when(volumeSourceBuilder.withDefaultTags(any())).thenReturn(volumeSourceBuilder);
         when(volumeSourceBuilder.build()).thenReturn(Mockito.mock(VolumeSource.class));
     }
 
@@ -103,8 +104,8 @@ class StaticQuotaCallbackTest {
         StaticQuotaCallback quotaCallback = new StaticQuotaCallback(volumeSourceBuilder, backgroundScheduler);
 
         quotaCallback.configure(Map.of(
-                StaticQuotaConfig.AVAILABLE_BYTES_PROP, 15L,
-                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10,
+                StaticQuotaConfig.AVAILABLE_BYTES_PROP, "15",
+                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
                 StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
         ));
 
@@ -125,8 +126,8 @@ class StaticQuotaCallbackTest {
         StaticQuotaCallback quotaCallback = new StaticQuotaCallback(volumeSourceBuilder, backgroundScheduler);
 
         quotaCallback.configure(Map.of(
-                StaticQuotaConfig.AVAILABLE_RATIO_PROP, 0.5,
-                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10,
+                StaticQuotaConfig.AVAILABLE_RATIO_PROP, "0.5",
+                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
                 StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
         ));
 
@@ -148,9 +149,9 @@ class StaticQuotaCallbackTest {
 
         //Then
         assertThrows(IllegalStateException.class, () -> quotaCallback.configure(Map.of(
-                StaticQuotaConfig.AVAILABLE_RATIO_PROP, 0.5,
-                StaticQuotaConfig.AVAILABLE_BYTES_PROP, 1,
-                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, 10,
+                StaticQuotaConfig.AVAILABLE_RATIO_PROP, "0.5",
+                StaticQuotaConfig.AVAILABLE_BYTES_PROP, "1",
+                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
                 StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
         )));
     }

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.quotas;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -294,5 +297,88 @@ class StaticQuotaCallbackTest {
         MetricName name = group.firstKey();
         String expectedMbeanName = String.format("io.strimzi.kafka.quotas:type=StaticQuotaCallback,name=%s", name.getName());
         assertEquals(expectedMbeanName, name.getMBeanName(), "unexpected mbean name");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenGroupContains(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource", "group" + illegalPattern);
+
+        //Then
+        assertThat(metricName.getGroup()).isEqualTo("group");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenTypeContains(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource" + illegalPattern, "group");
+
+        //Then
+        assertThat(metricName.getType()).isEqualTo("VolumeSource");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenTypeClassContains(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource" + illegalPattern, "group");
+
+        //Then
+        assertThat(metricName.getType()).isEqualTo("VolumeSource");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenGroupContainsWithTags(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource", "group" + illegalPattern, new LinkedHashMap<>());
+
+        //Then
+        assertThat(metricName.getGroup()).isEqualTo("group");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenTypeContainsWithTags(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource" + illegalPattern, "group", new LinkedHashMap<>());
+
+        //Then
+        assertThat(metricName.getType()).isEqualTo("VolumeSource");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(value = {"colon,:", "double forward slashes,//", "asterisk,*", "question mark,?"})
+    void shouldProduceValidMbeanObjectNamesWhenTypeClassContainsWithTags(String name, String illegalPattern) {
+        //Given
+
+        //When
+        final MetricName metricName = StaticQuotaCallback.metricName("class", "VolumeSource" + illegalPattern, "group", new LinkedHashMap<>());
+
+        //Then
+        assertThat(metricName.getType()).isEqualTo("VolumeSource");
+        assertNameComponentIsValid(metricName.getMBeanName());
+    }
+
+    private static void assertNameComponentIsValid(String component) {
+        assertThat(component).doesNotContain("$$", "//", "*", "?");
     }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -24,7 +24,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static io.strimzi.kafka.quotas.MetricUtils.METRICS_SCOPE;
 import static io.strimzi.kafka.quotas.MetricUtils.getMetricGroup;
+import static io.strimzi.kafka.quotas.MetricUtils.resetMetrics;
 import static io.strimzi.kafka.quotas.VolumeUsageResult.success;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
@@ -47,6 +49,7 @@ class StaticQuotaCallbackTest {
     private static final Map<String, Object> MINIMUM_EXECUTABLE_CONFIG = Map.of(StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, String.valueOf(STORAGE_CHECK_INTERVAL), StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092", StaticQuotaConfig.AVAILABLE_BYTES_PROP, "2");
     private static final long VOLUME_CAPACITY = 50;
     public static final long THROTTLE_FACTOR_EXPIRY_INTERVAL = 10L;
+    private static final String METRICS_TYPE = "StaticQuotaCallback";
 
     @Mock(lenient = true)
     VolumeSourceBuilder volumeSourceBuilder;
@@ -71,6 +74,7 @@ class StaticQuotaCallbackTest {
     @AfterEach
     void tearDown() {
         target.close();
+        resetMetrics(METRICS_SCOPE, METRICS_TYPE);
     }
 
     @Test
@@ -280,7 +284,7 @@ class StaticQuotaCallbackTest {
                 StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092"
         ));
 
-        SortedMap<MetricName, Metric> group = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "StaticQuotaCallback");
+        SortedMap<MetricName, Metric> group = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
 
         MetricUtils.assertGaugeMetric(group, "Produce", 15.0);
         MetricUtils.assertGaugeMetric(group, "Fetch", 16.0);

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -333,6 +333,43 @@ class VolumeSourceTest {
         assertGaugeMetric(volumeSourceMetrics, "ActiveBrokers", buildBasicTagMap(), 2L);
     }
 
+    @Test
+    void shouldCountEachActiveLogDirInDescribeLogDirsResponse() {
+        //Given
+        final int nodeId = 1;
+        final int node2Id = nodeId + 1;
+        givenNode(nodeId);
+        givenNode(node2Id);
+        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenLogDirDescription(nodeId, "dir2", 60, 15);
+        givenLogDirDescription(node2Id, "dir3", 40, 1);
+
+        //When
+        volumeSource.run();
+
+        //Then
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        assertGaugeMetric(volumeSourceMetrics, "ActiveLogDirs", buildBasicTagMap(), 3L);
+    }
+
+    @Test
+    void shouldCountEachValidLogDirInDescribeLogDirsResponse() {
+        //Given
+        final int nodeId = 1;
+        final int node2Id = nodeId + 1;
+        givenNode(nodeId);
+        givenNode(node2Id);
+        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenLogDirDescription(nodeId, "dir2", -1, -1);
+        givenLogDirDescription(node2Id, "dir3", 40, 1);
+
+        //When
+        volumeSource.run();
+
+        //Then
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        assertGaugeMetric(volumeSourceMetrics, "ActiveLogDirs", buildBasicTagMap(), 2L);
+    }
     private static LinkedHashMap<String, String> buildTagMap(int remoteNodeId, String logDir) {
         final LinkedHashMap<String, String> tags = buildBasicTagMap();
         tags.put(VolumeSource.REMOTE_BROKER_TAG, String.valueOf(remoteNodeId));

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -34,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.strimzi.kafka.quotas.MetricUtils.assertGaugeMetric;
 import static io.strimzi.kafka.quotas.MetricUtils.getMetricGroup;
+import static io.strimzi.kafka.quotas.StaticQuotaCallback.HOST_BROKER_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.lenient;
@@ -60,7 +61,9 @@ class VolumeSourceTest {
     @BeforeEach
     void setUp() {
         capturingVolumeObserver = new CapturingVolumeObserver();
-        volumeSource = new VolumeSource(LOCAL_NODE_ID, admin, capturingVolumeObserver, 0, TimeUnit.SECONDS);
+        final LinkedHashMap<String, String> tags = new LinkedHashMap<>();
+        tags.put(HOST_BROKER_TAG, LOCAL_NODE_ID);
+        volumeSource = new VolumeSource(admin, capturingVolumeObserver, 0, TimeUnit.SECONDS, tags);
         when(describeClusterResult.nodes()).thenReturn(KafkaFuture.completedFuture(nodes));
         when(admin.describeCluster()).thenReturn(describeClusterResult);
         when(describeLogDirsResult.allDescriptions()).thenReturn(KafkaFuture.completedFuture(descriptions));
@@ -309,7 +312,7 @@ class VolumeSourceTest {
 
     private static LinkedHashMap<String, String> buildTagMap(int remoteNodeId, String logDir) {
         final LinkedHashMap<String, String> dir1Tags = new LinkedHashMap<>();
-        dir1Tags.put(VolumeSource.HOST_BROKER_TAG, LOCAL_NODE_ID);
+        dir1Tags.put(HOST_BROKER_TAG, LOCAL_NODE_ID);
         dir1Tags.put(VolumeSource.REMOTE_BROKER_TAG, String.valueOf(remoteNodeId));
         dir1Tags.put(VolumeSource.LOG_DIR_TAG, logDir);
         return dir1Tags;

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -47,6 +47,13 @@ class VolumeSourceTest {
 
     private static final String LOCAL_NODE_ID = "3";
     private static final String METRICS_TYPE = "VolumeSource";
+    private static final int NODE_ID = 7;
+    private static final int NODE_2_ID = NODE_ID + 1;
+    private static final String NODE_ID_STRING = String.valueOf(NODE_ID);
+    private static final String NODE_2_ID_STRING = String.valueOf(NODE_2_ID);
+    private static final String LOG_DIR_1 = "/data/Dir1";
+    private static final String LOG_DIR_2 = "/data/Dir2";
+
     private CapturingVolumeObserver capturingVolumeObserver;
     private VolumeSource volumeSource;
     @Mock
@@ -153,9 +160,8 @@ class VolumeSourceTest {
     @Test
     void shouldProduceCollectionOfVolumes() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
 
         //When
         volumeSource.run();
@@ -163,15 +169,14 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        assertThat(onlyResult.getVolumeUsages()).containsExactly(new VolumeUsage("1", "dir1", 50, 10));
+        assertThat(onlyResult.getVolumeUsages()).containsExactly(new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10));
     }
 
     @Test
     void shouldCreateConsumedBytesMetricForALogDir() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
 
         //When
         volumeSource.run();
@@ -184,12 +189,11 @@ class VolumeSourceTest {
     @Test
     void shouldTrackEvolutionOfConsumedBytesMetricForALogDir() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
         volumeSource.run();
 
-        givenLogDirDescription(nodeId, "dir1", 50, 20);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 20);
 
         //When
         volumeSource.run();
@@ -202,12 +206,11 @@ class VolumeSourceTest {
     @Test
     void shouldTrackEvolutionOfAvailableBytesMetricForALogDir() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
         volumeSource.run();
 
-        givenLogDirDescription(nodeId, "dir1", 50, 20);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 20);
 
         //When
         volumeSource.run();
@@ -220,9 +223,8 @@ class VolumeSourceTest {
     @Test
     void shouldCreateAvailableBytesMetricForALogDir() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
 
         //When
         volumeSource.run();
@@ -235,52 +237,47 @@ class VolumeSourceTest {
     @Test
     void shouldCreateConsumedBytesMetricForEachLogDir() {
         //Given
-        final int nodeId = 1;
-        final int node2Id = nodeId + 1;
-        givenNode(nodeId);
-        givenNode(node2Id);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", 60, 15);
-        givenLogDirDescription(node2Id, "dir3", 40, 1);
+        givenNode(NODE_ID);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, 60, 15);
+        givenLogDirDescription(NODE_2_ID, "dir3", 40, 1);
 
         //When
         volumeSource.run();
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(nodeId, "dir1"), 40L);
-        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(nodeId, "dir2"), 45L);
-        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(node2Id, "dir3"), 39L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(NODE_ID, LOG_DIR_1), 40L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(NODE_ID, LOG_DIR_2), 45L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(NODE_2_ID, "dir3"), 39L);
     }
 
     @Test
     void shouldCreateAvailableBytesMetricForEachLogDir() {
         //Given
-        final int nodeId = 5;
-        final int node2Id = nodeId + 1;
-        givenNode(nodeId);
-        givenNode(node2Id);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", 60, 15);
-        givenLogDirDescription(node2Id, "dir3", 40, 1);
+        givenNode(NODE_ID);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, 60, 15);
+        givenLogDirDescription(NODE_2_ID, "dir3", 40, 1);
 
         //When
         volumeSource.run();
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(nodeId, "dir1"), 10L);
-        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(nodeId, "dir2"), 15L);
-        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(node2Id, "dir3"), 1L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(NODE_ID, LOG_DIR_1), 10L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(NODE_ID, LOG_DIR_2), 15L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(NODE_2_ID, "dir3"), 1L);
     }
 
     @Test
     void shouldProduceMultipleVolumesForASingleBrokerIfItHasMultipleLogDirs() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", 30, 5);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, 30, 5);
 
         //When
         volumeSource.run();
@@ -288,21 +285,19 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected1 = new VolumeUsage("1", "dir1", 50, 10);
-        VolumeUsage expected2 = new VolumeUsage("1", "dir2", 30, 5);
+        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10);
+        VolumeUsage expected2 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_2, 30, 5);
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected1, expected2);
     }
 
     @Test
     void shouldProduceMultipleVolumesForMultipleBrokers() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
 
-        int nodeId2 = 2;
-        givenNode(nodeId2);
-        givenLogDirDescription(nodeId2, "dir1", 30, 5);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_2_ID, LOG_DIR_1, 30, 5);
 
         //When
         volumeSource.run();
@@ -310,21 +305,19 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected1 = new VolumeUsage("1", "dir1", 50, 10);
-        VolumeUsage expected2 = new VolumeUsage("2", "dir1", 30, 5);
+        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10);
+        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5);
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected1, expected2);
     }
 
     @Test
     void shouldFilterVolumesWithoutAvailableBytes() {
         //Given
-        final int nodeId = 1;
-        givenNode(nodeId);
-        givenLogDirDescription(nodeId, "dir1", -1L, -1L);
+        givenNode(NODE_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, -1L, -1L);
 
-        int nodeId2 = 2;
-        givenNode(nodeId2);
-        givenLogDirDescription(nodeId2, "dir1", 30, 5);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_2_ID, LOG_DIR_1, 30, 5);
 
         //When
         volumeSource.run();
@@ -332,7 +325,7 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected2 = new VolumeUsage("2", "dir1", 30, 5);
+        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5);
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected2);
     }
 
@@ -353,13 +346,11 @@ class VolumeSourceTest {
     @Test
     void shouldCountEachActiveBrokerInDescribeClusterResponse() {
         //Given
-        final int nodeId = 1;
-        final int node2Id = nodeId + 1;
-        givenNode(nodeId);
-        givenNode(node2Id);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", 60, 15);
-        givenLogDirDescription(node2Id, "dir3", 40, 1);
+        givenNode(NODE_ID);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, 60, 15);
+        givenLogDirDescription(NODE_2_ID, "dir3", 40, 1);
 
         //When
         volumeSource.run();
@@ -372,13 +363,11 @@ class VolumeSourceTest {
     @Test
     void shouldCountEachActiveLogDirInDescribeLogDirsResponse() {
         //Given
-        final int nodeId = 1;
-        final int node2Id = nodeId + 1;
-        givenNode(nodeId);
-        givenNode(node2Id);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", 60, 15);
-        givenLogDirDescription(node2Id, "dir3", 40, 1);
+        givenNode(NODE_ID);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, 60, 15);
+        givenLogDirDescription(NODE_2_ID, "dir3", 40, 1);
 
         //When
         volumeSource.run();
@@ -391,13 +380,11 @@ class VolumeSourceTest {
     @Test
     void shouldCountEachValidLogDirInDescribeLogDirsResponse() {
         //Given
-        final int nodeId = 1;
-        final int node2Id = nodeId + 1;
-        givenNode(nodeId);
-        givenNode(node2Id);
-        givenLogDirDescription(nodeId, "dir1", 50, 10);
-        givenLogDirDescription(nodeId, "dir2", -1, -1);
-        givenLogDirDescription(node2Id, "dir3", 40, 1);
+        givenNode(NODE_ID);
+        givenNode(NODE_2_ID);
+        givenLogDirDescription(NODE_ID, LOG_DIR_1, 50, 10);
+        givenLogDirDescription(NODE_ID, LOG_DIR_2, -1, -1);
+        givenLogDirDescription(NODE_2_ID, "dir3", 40, 1);
 
         //When
         volumeSource.run();
@@ -406,6 +393,7 @@ class VolumeSourceTest {
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
         assertGaugeMetric(volumeSourceMetrics, "ActiveLogDirs", buildBasicTagMap(), 2L);
     }
+
     private static LinkedHashMap<String, String> buildTagMap(int remoteNodeId, String logDir) {
         final LinkedHashMap<String, String> tags = buildBasicTagMap();
         tags.put(VolumeSource.REMOTE_BROKER_TAG, String.valueOf(remoteNodeId));
@@ -431,7 +419,6 @@ class VolumeSourceTest {
             return actualResults;
         }
     }
-
 
     private void givenNode(int nodeId) {
         final Node singleNode = new Node(nodeId, "broker1", 9092);

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -182,6 +182,42 @@ class VolumeSourceTest {
     }
 
     @Test
+    void shouldTrackEvolutionOfConsumedBytesMetricForALogDir() {
+        //Given
+        final int nodeId = 1;
+        givenNode(nodeId);
+        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        volumeSource.run();
+
+        givenLogDirDescription(nodeId, "dir1", 50, 20);
+
+        //When
+        volumeSource.run();
+
+        //Then
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", 30L);
+    }
+
+    @Test
+    void shouldTrackEvolutionOfAvailableBytesMetricForALogDir() {
+        //Given
+        final int nodeId = 1;
+        givenNode(nodeId);
+        givenLogDirDescription(nodeId, "dir1", 50, 10);
+        volumeSource.run();
+
+        givenLogDirDescription(nodeId, "dir1", 50, 20);
+
+        //When
+        volumeSource.run();
+
+        //Then
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
+        assertGaugeMetric(volumeSourceMetrics, "available_bytes", 20L);
+    }
+
+    @Test
     void shouldCreateAvailableBytesMetricForALogDir() {
         //Given
         final int nodeId = 1;

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -178,7 +178,7 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", 40L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", 40L);
     }
 
     @Test
@@ -196,7 +196,7 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", 30L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", 30L);
     }
 
     @Test
@@ -214,7 +214,7 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "available_bytes", 20L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", 20L);
     }
 
     @Test
@@ -229,7 +229,7 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "available_bytes", 10L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", 10L);
     }
 
     @Test
@@ -248,9 +248,9 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(nodeId, "dir1"), 40L);
-        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(nodeId, "dir2"), 45L);
-        assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(node2Id, "dir3"), 39L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(nodeId, "dir1"), 40L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(nodeId, "dir2"), 45L);
+        assertGaugeMetric(volumeSourceMetrics, "ConsumedBytes", buildTagMap(node2Id, "dir3"), 39L);
     }
 
     @Test
@@ -269,9 +269,9 @@ class VolumeSourceTest {
 
         //Then
         final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
-        assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(nodeId, "dir1"), 10L);
-        assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(nodeId, "dir2"), 15L);
-        assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(node2Id, "dir3"), 1L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(nodeId, "dir1"), 10L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(nodeId, "dir2"), 15L);
+        assertGaugeMetric(volumeSourceMetrics, "AvailableBytes", buildTagMap(node2Id, "dir3"), 1L);
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -32,8 +32,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static io.strimzi.kafka.quotas.MetricUtils.METRICS_SCOPE;
 import static io.strimzi.kafka.quotas.MetricUtils.assertGaugeMetric;
 import static io.strimzi.kafka.quotas.MetricUtils.getMetricGroup;
+import static io.strimzi.kafka.quotas.MetricUtils.resetMetrics;
 import static io.strimzi.kafka.quotas.StaticQuotaCallback.HOST_BROKER_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.when;
 class VolumeSourceTest {
 
     private static final String LOCAL_NODE_ID = "3";
+    private static final String METRICS_TYPE = "VolumeSource";
     private CapturingVolumeObserver capturingVolumeObserver;
     private VolumeSource volumeSource;
     @Mock
@@ -60,6 +63,7 @@ class VolumeSourceTest {
 
     @BeforeEach
     void setUp() {
+        resetMetrics(METRICS_SCOPE, METRICS_TYPE);
         capturingVolumeObserver = new CapturingVolumeObserver();
         final LinkedHashMap<String, String> tags = new LinkedHashMap<>();
         tags.put(HOST_BROKER_TAG, LOCAL_NODE_ID);
@@ -173,7 +177,7 @@ class VolumeSourceTest {
         volumeSource.run();
 
         //Then
-        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "VolumeSource");
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
         assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", 40L);
     }
 
@@ -188,7 +192,7 @@ class VolumeSourceTest {
         volumeSource.run();
 
         //Then
-        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "VolumeSource");
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
         assertGaugeMetric(volumeSourceMetrics, "available_bytes", 10L);
     }
 
@@ -207,7 +211,7 @@ class VolumeSourceTest {
         volumeSource.run();
 
         //Then
-        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "VolumeSource");
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
         assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(nodeId, "dir1"), 40L);
         assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(nodeId, "dir2"), 45L);
         assertGaugeMetric(volumeSourceMetrics, "consumed_bytes", buildTagMap(node2Id, "dir3"), 39L);
@@ -228,7 +232,7 @@ class VolumeSourceTest {
         volumeSource.run();
 
         //Then
-        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup("io.strimzi.kafka.quotas.StaticQuotaCallback", "VolumeSource");
+        final SortedMap<MetricName, Metric> volumeSourceMetrics = getMetricGroup(METRICS_SCOPE, METRICS_TYPE);
         assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(nodeId, "dir1"), 10L);
         assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(nodeId, "dir2"), 15L);
         assertGaugeMetric(volumeSourceMetrics, "available_bytes", buildTagMap(node2Id, "dir3"), 1L);


### PR DESCRIPTION
This PR adds the metrics outlined in [proposal 47](https://github.com/strimzi/proposals/blob/main/047-cluster-wide-volume-usage-quota-management.md).

Note there are a couple of name changes in the implementation compared to the proposal:
| Proposal  | Implementation |
| ------------- | ------------- |
| `io.strimzi.kafka.quotas:type=LocalThrottleFactor,name=ThrottleFactor` | `io.strimzi.kafka.quotas:type=ThrottleFactor,name=ThrottleFactor` |
| `io.strimzi.kafka.quotas:type=LocalThrottleFactor,name=FallbackThrottleFactorApplied` | `io.strimzi.kafka.quotas:type=ThrottleFactor,name=FallbackThrottleFactorApplied` |
| `io.strimzi.kafka.quotas:type=LocalThrottleFactor,name=LimitViolated` | `io.strimzi.kafka.quotas:type=ThrottleFactor,name=LimitViolated` |
| `io.strimzi.kafka.quotas:type=ClusterVolumeSouce,name=ActiveBrokers` | `io.strimzi.kafka.quotas:type=VolumeSouce,name=ActiveBrokers` |
| `io.strimzi.kafka.quotas:type=ClusterVolumeSouce,name=ActiveLogDirs` | `io.strimzi.kafka.quotas:type=VolumeSouce,name=ActiveLogDirs` |

In short `LocalThrottleFactor` -> `ThrottleFactor` and `ClusterVolumeSource` -> `VolumeSource` as the local and cluster distinctions no longer make sense (I don't think they actually did when merged the proposal but no one picked up on the fact we had lost the distinction).

### The Metrics

| Name | Metric Type | Meaning | Type | Tags |
| ---- | ---- | ---- | ---- | ---- |
| ThrottleFactor | Gauge |The current factor applied by the plug-in [0..1] | ThrottleFactor | `observingBrokerId` |
| FallbackThrottleFactorApplied | Counter |  The number of times the plug-in has transitioned to using the fall back factor | ThrottleFactor | `observingBrokerId` |
| LimitViolated | Counter | A count of the number `logDir`s which violate the configured limit | ThrottleFactor | `observingBrokerId` |
| ActiveBrokers | Gauge | The current number of brokers returned by the describeCluster rpc | VolumeSource | `observingBrokerId` |
| ActiveLogDirs | Gauge | The number of logDirs returned by the describeLogDirs RPC | VolumeSource | `observingBrokerId` | 
| available_bytes | Gauge | The number of available bytes returned by the describeLogDirs RPC | VolumeSource | `[observingBrokerId, remoteBrokerId, logDir]` |
| consumed_bytes | Gauge | The number of consumed bytes returned by the describeLogDirs RPC | VolumeSource | `[observingBrokerId, remoteBrokerId, logDir]` |

### Tag definitions
| Tag | Definition |
| ---- | ---- |
| observingBrokerId | The BrokerId of the broker node executing the plug-in |
| remoteBrokerId | The BrokerId of the broker node hosting the logDir |
| logDir | The path to the specific logDir as returned by the describeLogDirs RPC |
