### PR TITLE
Add caching of volume observations to mitigate inconsistencies between API calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ The plugin currently provides the following metrics:
 
 ### Additional metrics for cluster wide monitoring
 
-| Name                          | Metric Type | Meaning                                                                        | Type           | Tags                                          |
-|-------------------------------|-------------|--------------------------------------------------------------------------------|----------------|-----------------------------------------------|
-| ThrottleFactor                | Gauge       | The current factor applied by the plug-in [0..1]                               | ThrottleFactor | `observingBrokerId`                           |
-| FallbackThrottleFactorApplied | Counter     | The number of times the plug-in has transitioned to using the fall back factor | ThrottleFactor | `observingBrokerId`                           |
-| LimitViolated                 | Counter     | A count of the number `logDir`s which violate the configured limit             | ThrottleFactor | `observingBrokerId`                           |
-| ActiveBrokers                 | Gauge       | The current number of brokers returned by the describeCluster rpc              | VolumeSource   | `observingBrokerId`                           |
-| ActiveLogDirs                 | Gauge       | The number of logDirs returned by the describeLogDirs RPC                      | VolumeSource   | `observingBrokerId`                           | 
-| AvailableBytes                | Gauge       | The number of available bytes returned by the describeLogDirs RPC              | VolumeSource   | `[observingBrokerId, remoteBrokerId, logDir]` |
-| ConsumedBytes                 | Gauge       | The number of consumed bytes returned by the describeLogDirs RPC               | VolumeSource   | `[observingBrokerId, remoteBrokerId, logDir]` |
+| Name                          | Metric Type | Meaning                                                                        | Type                  | Tags                                          |
+|-------------------------------|-------------|--------------------------------------------------------------------------------|-----------------------|-----------------------------------------------|
+| ThrottleFactor                | Gauge       | The current factor applied by the plug-in [0..1]                               | ThrottleFactor        | `observingBrokerId`                           |
+| FallbackThrottleFactorApplied | Counter     | The number of times the plug-in has transitioned to using the fall back factor | ThrottleFactor        | `observingBrokerId`                           |
+| LimitViolated                 | Counter     | A count of the number `logDir`s which violate the configured limit             | ThrottleFactor        | `observingBrokerId`                           |
+| ActiveBrokers                 | Gauge       | The current number of brokers returned by the describeCluster rpc              | VolumeSource          | `observingBrokerId`                           |
+| ActiveLogDirs                 | Gauge       | The number of logDirs returned by the describeLogDirs RPC                      | VolumeSource          | `observingBrokerId`                           | 
+| AvailableBytes                | Gauge       | The number of available bytes returned by the describeLogDirs RPC              | VolumeSource          | `[observingBrokerId, remoteBrokerId, logDir]` |
+| ConsumedBytes                 | Gauge       | The number of consumed bytes returned by the describeLogDirs RPC               | VolumeSource          | `[observingBrokerId, remoteBrokerId, logDir]` |
+| CachedEntries                 | Gauge       | The number of logDirs currently cached by the plug-in                          | CachingVolumeObserver | `observingBrokerId`                           |
+| LogDirEvictions               | Counter     | The number of times each remoteBroker.logDir has been removed from the cache.  | CachingVolumeObserver | `[observingBrokerId, remoteBrokerId, logDir]` |
 
 ### Tag definitions
 | Tag               | Definition                                                             |

--- a/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
+++ b/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
@@ -86,7 +86,7 @@ public class CachingVolumeObserver implements VolumeObserver {
     }
 
     private void evict(CacheKey key) {
-        final Counter counter = getEvictionCounter(key);
+        final Counter counter = evictionCounter(key);
         counter.inc();
         if (log.isDebugEnabled()) {
             log.debug("evicting entry logDir: {} on broker: {}", key.logDir, key.brokerId);
@@ -94,7 +94,7 @@ public class CachingVolumeObserver implements VolumeObserver {
         cachedObservations.remove(key);
     }
 
-    private Counter getEvictionCounter(CacheKey key) {
+    private Counter evictionCounter(CacheKey key) {
         return evictionsPerRemoteBroker.computeIfAbsent(key, key1 -> buildCounterForCacheKey("LogDirEvictions", key1));
     }
 
@@ -124,7 +124,8 @@ public class CachingVolumeObserver implements VolumeObserver {
 
     private CacheKey createCacheKey(VolumeUsage usage) {
         final CacheKey key = new CacheKey(usage.getBrokerId(), usage.getLogDir());
-        getEvictionCounter(key);
+        //eagerly get the eviction counter, rather than on first eviction, to ensure it is initialised to zero.
+        evictionCounter(key);
         return key;
     }
 

--- a/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
+++ b/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
@@ -95,14 +95,14 @@ public class CachingVolumeObserver implements VolumeObserver {
     }
 
     private Counter evictionCounter(CacheKey key) {
-        return evictionsPerRemoteBroker.computeIfAbsent(key, key1 -> buildCounterForCacheKey("LogDirEvictions", key1));
+        return evictionsPerRemoteBroker.computeIfAbsent(key, this::buildEvictionCounter);
     }
 
-    private Counter buildCounterForCacheKey(String name, CacheKey cacheKey) {
+    private Counter buildEvictionCounter(CacheKey cacheKey) {
         LinkedHashMap<String, String> tags = new LinkedHashMap<>(defaultTags);
         tags.put(StaticQuotaCallback.REMOTE_BROKER_TAG, cacheKey.brokerId);
         tags.put(StaticQuotaCallback.LOG_DIR_TAG, cacheKey.logDir);
-        return Metrics.newCounter(metricName(CachingVolumeObserver.class, name, tags));
+        return Metrics.newCounter(metricName(CachingVolumeObserver.class, "LogDirEvictions", tags));
     }
 
     private boolean isExpired(VolumeUsage usage) {

--- a/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
+++ b/src/main/java/io/strimzi/kafka/quotas/CachingVolumeObserver.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static io.strimzi.kafka.quotas.VolumeUsageResult.VolumeSourceObservationStatus.SUCCESS;
+
+/**
+ * Volume Observer that remembers the most recent observation for each brokerId. Then when it observes new result it
+ * can augment in observations from brokers that have dropped out of the results (due to being restarted or otherwise
+ * removed from the active set of brokers).
+ */
+public class CachingVolumeObserver implements VolumeObserver {
+    private final VolumeObserver observer;
+    private final Clock clock;
+    private final ConcurrentMap<CacheKey, VolumeUsage> cachedObservations;
+
+    /**
+     * @param observer
+     * @param clock
+     */
+    public CachingVolumeObserver(VolumeObserver observer, Clock clock) {
+        this.observer = observer;
+        this.clock = clock;
+        cachedObservations = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void observeVolumeUsage(VolumeUsageResult result) {
+        maybeExpireCachedObservations();
+        VolumeUsageResult outgoing;
+        if (result.getStatus() == SUCCESS) {
+            outgoing = cacheAndAugment(result);
+        } else {
+            outgoing = result;
+        }
+        observer.observeVolumeUsage(outgoing);
+    }
+
+    private void maybeExpireCachedObservations() {
+        Set<CacheKey> toRemove = cachedObservations.entrySet().stream()
+                .filter(e -> isExpired(e.getValue())).map(Map.Entry::getKey).collect(Collectors.toSet());
+        toRemove.forEach(cachedObservations::remove);
+    }
+
+    private boolean isExpired(VolumeUsage usage) {
+        Instant expiry = usage.getObservedAt().plus(Duration.ofSeconds(60));
+        Instant now = clock.instant();
+        return now.equals(expiry) || now.isAfter(expiry);
+    }
+
+    private VolumeUsageResult cacheAndAugment(VolumeUsageResult result) {
+        cachedObservations.putAll(result.getVolumeUsages()
+                .stream()
+                .collect(Collectors.toMap(usage -> new CacheKey(usage.getBrokerId(), usage.getLogDir()), usage -> usage)));
+
+        final Collection<VolumeUsage> mergedUsage = Set.copyOf(cachedObservations.values());
+
+        return VolumeUsageResult.replaceObservations(result, mergedUsage);
+    }
+
+    private static class CacheKey {
+
+        private final String brokerId;
+        private final String logDir;
+
+        public CacheKey(String topic, String logDir) {
+            this.brokerId = topic;
+            this.logDir = logDir;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(brokerId, cacheKey.brokerId) && Objects.equals(logDir, cacheKey.logDir);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(brokerId, logDir);
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -236,7 +236,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
         final String sanitisedGroup = sanitise(group);
         final String sanitisedType = sanitise(type);
         final String sanitisedName = sanitise(name);
-        String mBeanName = java.lang.String.format("%s:type=%s,name=%s", sanitisedGroup, sanitisedType, sanitisedName);
+        String mBeanName = String.format("%s:type=%s,name=%s", sanitisedGroup, sanitisedType, sanitisedName);
         return new MetricName(sanitisedGroup, sanitisedType, sanitisedName, SCOPE, mBeanName);
     }
 
@@ -250,15 +250,15 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
      * @return the MetricName object derived from the arguments.
      */
     public static MetricName metricName(String name, String type, String group, LinkedHashMap<String, String> tags) {
-        final String tagValues = tags.entrySet().stream().map(entry -> java.lang.String.format("%s=%s", sanitise(entry.getKey()), sanitise(entry.getValue()))).collect(Collectors.joining(","));
+        final String tagValues = tags.entrySet().stream().map(entry -> String.format("%s=%s", sanitise(entry.getKey()), sanitise(entry.getValue()))).collect(Collectors.joining(","));
         String mBeanName;
         final String sanitisedGroup = sanitise(group);
         final String sanitisedType = sanitise(type);
         final String sanitisedName = sanitise(name);
         if (!tagValues.isBlank()) {
-            mBeanName = java.lang.String.format("%s:type=%s,name=%s,%s", sanitisedGroup, sanitisedType, sanitisedName, tagValues);
+            mBeanName = String.format("%s:type=%s,name=%s,%s", sanitisedGroup, sanitisedType, sanitisedName, tagValues);
         } else {
-            mBeanName = java.lang.String.format("%s:type=%s,name=%s", sanitisedGroup, sanitisedType, sanitisedName);
+            mBeanName = String.format("%s:type=%s,name=%s", sanitisedGroup, sanitisedType, sanitisedName);
         }
         return new MetricName(sanitisedGroup, sanitisedType, sanitisedName, SCOPE, mBeanName);
     }

--- a/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
+++ b/src/main/java/io/strimzi/kafka/quotas/StaticQuotaCallback.java
@@ -44,6 +44,14 @@ import static java.util.Locale.ENGLISH;
  * Allows configuring generic quotas for a broker independent of users and clients.
  */
 public class StaticQuotaCallback implements ClientQuotaCallback {
+    /**
+     * Tag used for metrics to identify the broker which generated the observation.
+     */
+    public static final String REMOTE_BROKER_TAG = "remoteBrokerId";
+    /**
+     * Tag used for metrics to identify the logDir included in the observation.
+     */
+    public static final String LOG_DIR_TAG = "logDir";
     private static final Logger log = LoggerFactory.getLogger(StaticQuotaCallback.class);
     private static final String EXCLUDED_PRINCIPAL_QUOTA_KEY = "excluded-principal-quota-key";
     private final Clock clock;
@@ -177,7 +185,7 @@ public class StaticQuotaCallback implements ClientQuotaCallback {
             final PolicyBasedThrottle factorNotifier = new PolicyBasedThrottle(throttleFactorPolicy, () -> resetQuota.add(ClientQuotaType.PRODUCE), expiryPolicy, config.getFallbackThrottleFactor(), defaultTags);
             throttleFactorSource = factorNotifier;
 
-            VolumeObserver observer = new CachingVolumeObserver(factorNotifier, clock, config.getThrottleFactorValidityDuration());
+            VolumeObserver observer = new CachingVolumeObserver(factorNotifier, clock, config.getThrottleFactorValidityDuration(), defaultTags);
             Runnable volumeSource = volumeSourceBuilder.withConfig(config).withVolumeObserver(observer).withDefaultTags(defaultTags).build();
             backgroundScheduler.scheduleWithFixedDelay(volumeSource, 0, storageCheckInterval, TimeUnit.SECONDS);
             backgroundScheduler.scheduleWithFixedDelay(factorNotifier::checkThrottleFactorValidity, 0, 10, TimeUnit.SECONDS);

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -48,16 +48,6 @@ import static java.util.stream.Collectors.toSet;
  */
 public class VolumeSource implements Runnable {
 
-    /**
-     * Tag used for metrics to identify the borker which generated the observation.
-     */
-    public static final String REMOTE_BROKER_TAG = "remoteBrokerId";
-
-    /**
-     * Tag used for metrics to identify the logDir included in the observation.
-     */
-    public static final String LOG_DIR_TAG = "logDir";
-
     private final VolumeObserver volumeObserver;
     private final Admin admin;
     private final int timeout;
@@ -200,8 +190,8 @@ public class VolumeSource implements Runnable {
 
     private LinkedHashMap<String, String> buildTagMap(VolumeUsage volumeUsage) {
         final LinkedHashMap<String, String> tags = new LinkedHashMap<>(defaultTags);
-        tags.put(REMOTE_BROKER_TAG, volumeUsage.getBrokerId());
-        tags.put(LOG_DIR_TAG, volumeUsage.getLogDir());
+        tags.put(StaticQuotaCallback.REMOTE_BROKER_TAG, volumeUsage.getBrokerId());
+        tags.put(StaticQuotaCallback.LOG_DIR_TAG, volumeUsage.getLogDir());
         return tags;
     }
 

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -212,7 +213,8 @@ public class VolumeSource implements Runnable {
             if (logDirDescription.totalBytes().isPresent() && logDirDescription.usableBytes().isPresent()) {
                 final long totalBytes = logDirDescription.totalBytes().getAsLong();
                 final long usableBytes = logDirDescription.usableBytes().getAsLong();
-                return new VolumeUsage(String.valueOf(brokerIdToLogDirs.getKey()), logDirs.getKey(), totalBytes, usableBytes);
+                // TODO clock instead of Instant.now()
+                return new VolumeUsage(String.valueOf(brokerIdToLogDirs.getKey()), logDirs.getKey(), totalBytes, usableBytes, Instant.now());
             } else {
                 return null;
             }

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeSource.java
@@ -124,7 +124,7 @@ public class VolumeSource implements Runnable {
 
     private void notifyObserver(VolumeUsageResult result) {
         if (log.isDebugEnabled()) {
-            log.debug("Notifying consumers of volumes usage result: " + result);
+            log.debug("Notifying consumers of volumes usage result: {}", result);
         }
         volumeObserver.observeVolumeUsage(result);
     }
@@ -159,7 +159,7 @@ public class VolumeSource implements Runnable {
 
     private VolumeUsageResult onDescribeLogDirSuccess(Map<Integer, Map<String, LogDirDescription>> logDirsPerBroker) {
         if (log.isDebugEnabled()) {
-            log.debug("Successfully described logDirs: " + logDirsPerBroker);
+            log.debug("Successfully described logDirs: {}", logDirsPerBroker);
         }
         List<VolumeUsage> volumeUsages = logDirsPerBroker.entrySet()
                 .stream()

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeUsage.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeUsage.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -15,6 +16,7 @@ public class VolumeUsage {
     private final String logDir;
     private final long capacity;
     private final long availableBytes;
+    private final Instant observedAt;
 
     /**
      * Represents a snapshot of volume usage.
@@ -22,12 +24,14 @@ public class VolumeUsage {
      * @param logDir the specific logDir the volume hosts
      * @param capacity How many bytes the volume holds
      * @param availableBytes How many available bytes remain on the volume.
+     * @param observedAt When this volume usage was observed
      */
-    public VolumeUsage(String brokerId, String logDir, long capacity, long availableBytes) {
+    public VolumeUsage(String brokerId, String logDir, long capacity, long availableBytes, Instant observedAt) {
         this.brokerId = brokerId;
         this.logDir = logDir;
         this.capacity = capacity;
         this.availableBytes = availableBytes;
+        this.observedAt = observedAt;
     }
 
     /**
@@ -79,6 +83,13 @@ public class VolumeUsage {
             return 0;
         }
         return (double) availableBytes / capacity;
+    }
+
+    /**
+     * @return An instant marking when the observation was recorded by the observing broker
+     */
+    public Instant getObservedAt() {
+        return observedAt;
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeUsageResult.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeUsageResult.java
@@ -4,8 +4,10 @@
  */
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 
@@ -33,6 +35,14 @@ public class VolumeUsageResult {
      */
     public VolumeSourceObservationStatus getStatus() {
         return status;
+    }
+
+    /**
+     * The most recent value for when the log dirs were observed
+     * @return An instant marking the most recent observation of any log dir.
+     */
+    public Instant getObservedAt() {
+        return volumeUsages.stream().map(VolumeUsage::getObservedAt).max(Comparator.naturalOrder()).orElseThrow();
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/quotas/VolumeUsageResult.java
+++ b/src/main/java/io/strimzi/kafka/quotas/VolumeUsageResult.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -118,6 +119,16 @@ public class VolumeUsageResult {
         return new VolumeUsageResult(List.of(), status, cause);
     }
 
+    /**
+     * Clone the original observation and replace the set of observations with the replacements.
+     * @param original the VolumeUsageResult to be copied
+     * @param replacement the replacement set of observations
+     * @return The merged VolumeUsageResult
+     */
+    public static VolumeUsageResult replaceObservations(VolumeUsageResult original, Collection<VolumeUsage> replacement) {
+        return new VolumeUsageResult(replacement, original.status, original.causeOfFailure);
+    }
+
     @Override
     public String toString() {
         return "VolumeUsageObservation{" +
@@ -125,5 +136,18 @@ public class VolumeUsageResult {
                 ", status=" + status +
                 ", throwable=" + causeOfFailure +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VolumeUsageResult that = (VolumeUsageResult) o;
+        return Objects.equals(volumeUsages, that.volumeUsages) && status == that.status && Objects.equals(causeOfFailure, that.causeOfFailure);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(volumeUsages, status, causeOfFailure);
     }
 }

--- a/src/main/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottle.java
+++ b/src/main/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottle.java
@@ -6,7 +6,7 @@ package io.strimzi.kafka.quotas.throttle;
 
 import java.time.Clock;
 import java.util.LinkedHashMap;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
@@ -85,14 +85,14 @@ public class PolicyBasedThrottle implements VolumeObserver, ThrottleFactorSource
         }
     }
 
-    private void updateFactor(Function<ThrottleFactor, ThrottleFactor> throttleFactorUpdater) {
+    private void updateFactor(UnaryOperator<ThrottleFactor> throttleFactorUpdater) {
         boolean changed = updateFactorAndCheckIfChanged(throttleFactorUpdater);
         if (changed) {
             listener.run();
         }
     }
 
-    private synchronized boolean updateFactorAndCheckIfChanged(Function<ThrottleFactor, ThrottleFactor> throttleFactorUpdater) {
+    private synchronized boolean updateFactorAndCheckIfChanged(UnaryOperator<ThrottleFactor> throttleFactorUpdater) {
         ThrottleFactor currentFactor = this.throttleFactor;
         throttleFactor = throttleFactorUpdater.apply(currentFactor);
         boolean changed = currentFactor.getThrottleFactor() != throttleFactor.getThrottleFactor();
@@ -123,5 +123,3 @@ public class PolicyBasedThrottle implements VolumeObserver, ThrottleFactorSource
     }
 
 }
-
-

--- a/src/test/java/io/strimzi/kafka/quotas/AvailableBytesThrottleFactorPolicyTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/AvailableBytesThrottleFactorPolicyTest.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.SortedMap;
 
@@ -108,6 +109,6 @@ class AvailableBytesThrottleFactorPolicyTest {
     }
 
     private static VolumeUsage volumeWithAvailableBytes(long availableBytes) {
-        return new VolumeUsage("0", "/var/lib/data", 1000L, availableBytes);
+        return new VolumeUsage("0", "/var/lib/data", 1000L, availableBytes, Instant.now());
     }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
@@ -5,14 +5,15 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
+import java.util.List;
+
 import io.strimzi.kafka.quotas.throttle.AvailableRatioThrottleFactorPolicy;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/AvailableRatioThrottleFactorPolicyTest.java
@@ -80,7 +80,7 @@ class AvailableRatioThrottleFactorPolicyTest {
         //When
         long capacity = 0L;
         final double actualFactor = availableBytesThrottleFactorSupplier.calculateFactor(List.of(volumeWithAvailableRatio(0.5),
-                new VolumeUsage("0", "/var/lib/data", capacity, 100)));
+                new VolumeUsage("0", "/var/lib/data", capacity, 100, Instant.now())));
 
         //Then
         assertThat(actualFactor).isCloseTo(0.0d, OFFSET);
@@ -88,6 +88,6 @@ class AvailableRatioThrottleFactorPolicyTest {
 
     private static VolumeUsage volumeWithAvailableRatio(double availableRatio) {
         int available = 100;
-        return new VolumeUsage("0", "/var/lib/data", (long) (available / availableRatio), available);
+        return new VolumeUsage("0", "/var/lib/data", (long) (available / availableRatio), available, Instant.now());
     }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/CachingVolumeObserverTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/CachingVolumeObserverTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CachingVolumeObserverTest {
+
+    @Mock
+    private VolumeObserver downstreamObserver;
+    private VolumeObserver cachingObserver;
+
+    @BeforeEach
+    void setUp() {
+        cachingObserver = new CachingVolumeObserver(downstreamObserver, Clock.systemUTC());
+    }
+
+    @Test
+    void shouldPassThroughFirstObservationUnaltered() {
+        // given
+        VolumeUsageResult result = VolumeUsageResult.success(Set.of());
+
+        // when
+        cachingObserver.observeVolumeUsage(result);
+
+        // then
+        verify(downstreamObserver).observeVolumeUsage(result);
+    }
+
+    @Test
+    void shouldMergeCachedObservationForMissingBroker() {
+        // Given
+        final VolumeUsage broker0Initial = new VolumeUsage("0", "/var/lib/data", 1000, 1000, Instant.now());
+        final VolumeUsage broker1Initial = new VolumeUsage("1", "/var/lib/data", 1000, 1000, Instant.now());
+        VolumeUsageResult primingObservation = VolumeUsageResult.success(Set.of(broker0Initial, broker1Initial));
+        cachingObserver.observeVolumeUsage(primingObservation);
+        final VolumeUsage broker1Final = new VolumeUsage("1", "/var/lib/data", 1000, 500, Instant.now());
+
+        // When
+        cachingObserver.observeVolumeUsage(VolumeUsageResult.success(Set.of(broker1Final)));
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(VolumeUsageResult.success(Set.of(broker0Initial, broker1Final)));
+    }
+
+    @Test
+    void shouldForwardFreshObservation() {
+        // Given
+        final VolumeUsage broker0Initial = new VolumeUsage("0", "/var/lib/data", 1000, 1000, Instant.now());
+        final VolumeUsage broker1Initial = new VolumeUsage("1", "/var/lib/data", 1000, 1000, Instant.now());
+        VolumeUsageResult primingObservation = VolumeUsageResult.success(Set.of(broker0Initial, broker1Initial));
+        cachingObserver.observeVolumeUsage(primingObservation);
+        final VolumeUsage broker0Final = new VolumeUsage("0", "/var/lib/data", 1000, 500, Instant.now());
+        final VolumeUsage broker1Final = new VolumeUsage("1", "/var/lib/data", 1000, 500, Instant.now());
+        final VolumeUsageResult expectedResult = VolumeUsageResult.success(Set.of(broker0Final, broker1Final));
+
+        // When
+        cachingObserver.observeVolumeUsage(expectedResult);
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(expectedResult);
+    }
+
+    @Test
+    void shouldForwardFailedObservation() {
+        // Given
+        VolumeUsageResult primingObservation = VolumeUsageResult.failure(VolumeUsageResult.VolumeSourceObservationStatus.DESCRIBE_CLUSTER_ERROR, IllegalStateException.class);
+
+        // When
+        cachingObserver.observeVolumeUsage(primingObservation);
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(primingObservation);
+    }
+
+    @Test
+    void shouldUseOldCacheEntryJustBeforeExpiry() {
+        // Given
+        final TickableClock clock = new TickableClock();
+        cachingObserver = new CachingVolumeObserver(downstreamObserver, clock);
+        final Instant initialObservationTime = clock.instant();
+        final VolumeUsage broker0Initial = new VolumeUsage("0", "/var/lib/data", 1000, 1000, initialObservationTime);
+        final VolumeUsage broker1Initial = new VolumeUsage("1", "/var/lib/data", 1000, 1000, initialObservationTime);
+        VolumeUsageResult primingObservation = VolumeUsageResult.success(Set.of(broker0Initial, broker1Initial));
+        cachingObserver.observeVolumeUsage(primingObservation);
+
+        Duration beforeExpiry = Duration.ofSeconds(60).minusNanos(1);
+        clock.tick(beforeExpiry);
+        final Instant updatedObservationTime = clock.instant();
+        final VolumeUsage broker1Final = new VolumeUsage("1", "/var/lib/data", 1000, 500, updatedObservationTime);
+        final VolumeUsageResult subsequentObservation = VolumeUsageResult.success(Set.of(broker1Final));
+
+        // When
+        cachingObserver.observeVolumeUsage(subsequentObservation);
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(VolumeUsageResult.success(Set.of(broker0Initial, broker1Final)));
+    }
+
+    @Test
+    void shouldExpireOldCacheEntriesOnUpdateExactlyAtExpiryBoundary() {
+        // Given
+        final TickableClock clock = new TickableClock();
+        cachingObserver = new CachingVolumeObserver(downstreamObserver, clock);
+        final Instant initialObservationTime = clock.instant();
+        final VolumeUsage broker0Initial = new VolumeUsage("0", "/var/lib/data", 1000, 1000, initialObservationTime);
+        final VolumeUsage broker1Initial = new VolumeUsage("1", "/var/lib/data", 1000, 1000, initialObservationTime);
+        VolumeUsageResult primingObservation = VolumeUsageResult.success(Set.of(broker0Initial, broker1Initial));
+        cachingObserver.observeVolumeUsage(primingObservation);
+
+        clock.tick(Duration.ofSeconds(60));
+        final Instant updatedObservationTime = clock.instant();
+        final VolumeUsage broker1Final = new VolumeUsage("1", "/var/lib/data", 1000, 500, updatedObservationTime);
+        final VolumeUsageResult subsequentObservation = VolumeUsageResult.success(Set.of(broker1Final));
+
+        // When
+        cachingObserver.observeVolumeUsage(subsequentObservation);
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(VolumeUsageResult.success(Set.of(broker1Final)));
+    }
+
+    @Test
+    void shouldExpireOldCacheEntriesOnUpdateAfterExpiryBoundary() {
+        // Given
+        final TickableClock clock = new TickableClock();
+        cachingObserver = new CachingVolumeObserver(downstreamObserver, clock);
+        final Instant initialObservationTime = clock.instant();
+        final VolumeUsage broker0Initial = new VolumeUsage("0", "/var/lib/data", 1000, 1000, initialObservationTime);
+        final VolumeUsage broker1Initial = new VolumeUsage("1", "/var/lib/data", 1000, 1000, initialObservationTime);
+        VolumeUsageResult primingObservation = VolumeUsageResult.success(Set.of(broker0Initial, broker1Initial));
+        cachingObserver.observeVolumeUsage(primingObservation);
+
+        Duration afterExpiryBoundary = Duration.ofSeconds(60).plusNanos(1);
+        clock.tick(afterExpiryBoundary);
+        final Instant updatedObservationTime = clock.instant();
+        final VolumeUsage broker1Final = new VolumeUsage("1", "/var/lib/data", 1000, 500, updatedObservationTime);
+        final VolumeUsageResult subsequentObservation = VolumeUsageResult.success(Set.of(broker1Final));
+
+        // When
+        cachingObserver.observeVolumeUsage(subsequentObservation);
+
+        // Then
+        verify(downstreamObserver).observeVolumeUsage(VolumeUsageResult.success(Set.of(broker1Final)));
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +61,7 @@ class StaticQuotaCallbackTest {
     VolumeSourceBuilder volumeSourceBuilder;
 
     private static VolumeUsage newVolume(long availableBytes) {
-        return new VolumeUsage("-1", "test", VOLUME_CAPACITY, availableBytes);
+        return new VolumeUsage("-1", "test", VOLUME_CAPACITY, availableBytes, Instant.now());
     }
 
     StaticQuotaCallback target;
@@ -144,7 +145,7 @@ class StaticQuotaCallbackTest {
         ));
 
         //When
-        argument.getValue().observeVolumeUsage(success(List.of(new VolumeUsage("-1", "test", 30L, 15L))));
+        argument.getValue().observeVolumeUsage(success(List.of(new VolumeUsage("-1", "test", 30L, 15L, Instant.now()))));
 
         //Then
         double quotaLimit = quotaCallback.quotaLimit(ClientQuotaType.PRODUCE, Map.of());

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.quotas;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -169,7 +170,7 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        assertThat(onlyResult.getVolumeUsages()).containsExactly(new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10));
+        assertThat(onlyResult.getVolumeUsages()).containsExactly(new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10, Instant.now()));
     }
 
     @Test
@@ -285,8 +286,8 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10);
-        VolumeUsage expected2 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_2, 30, 5);
+        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10, Instant.now());
+        VolumeUsage expected2 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_2, 30, 5, Instant.now());
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected1, expected2);
     }
 
@@ -305,8 +306,8 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10);
-        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5);
+        VolumeUsage expected1 = new VolumeUsage(NODE_ID_STRING, LOG_DIR_1, 50, 10, Instant.now());
+        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5, Instant.now());
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected1, expected2);
     }
 
@@ -325,7 +326,7 @@ class VolumeSourceTest {
         //Then
         final List<VolumeUsageResult> results = capturingVolumeObserver.getActualResults();
         final VolumeUsageResult onlyResult = assertVolumeUsageStatus(results, VolumeSourceObservationStatus.SUCCESS);
-        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5);
+        VolumeUsage expected2 = new VolumeUsage(NODE_2_ID_STRING, LOG_DIR_1, 30, 5, Instant.now());
         assertThat(onlyResult.getVolumeUsages()).containsExactlyInAnyOrder(expected2);
     }
 

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeSourceTest.java
@@ -397,8 +397,8 @@ class VolumeSourceTest {
 
     private static LinkedHashMap<String, String> buildTagMap(int remoteNodeId, String logDir) {
         final LinkedHashMap<String, String> tags = buildBasicTagMap();
-        tags.put(VolumeSource.REMOTE_BROKER_TAG, String.valueOf(remoteNodeId));
-        tags.put(VolumeSource.LOG_DIR_TAG, logDir);
+        tags.put(StaticQuotaCallback.REMOTE_BROKER_TAG, String.valueOf(remoteNodeId));
+        tags.put(StaticQuotaCallback.LOG_DIR_TAG, logDir);
         return tags;
     }
 

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeUsageResultTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeUsageResultTest.java
@@ -44,4 +44,20 @@ class VolumeUsageResultTest {
         // Then
         assertThat(actual).isEqualTo(later);
     }
+
+    @Test
+    void shoul() {
+        // Given
+        Instant earlier = Instant.now().truncatedTo(ChronoUnit.DAYS);
+        Instant later = earlier.plus(1, ChronoUnit.DAYS);
+        final VolumeUsage volumeUsage = new VolumeUsage("0", "/var/log/data", 1000, 1000, earlier);
+        final VolumeUsage volumeUsage2 = new VolumeUsage("1", "/var/log/data", 1000, 1000, later);
+        VolumeUsageResult result = VolumeUsageResult.success(List.of(volumeUsage, volumeUsage2));
+
+        // When
+        Instant actual = result.getObservedAt();
+
+        // Then
+        assertThat(actual).isEqualTo(later);
+    }
 }

--- a/src/test/java/io/strimzi/kafka/quotas/VolumeUsageResultTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/VolumeUsageResultTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.quotas;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VolumeUsageResultTest {
+
+    @Test
+    void shouldSupplyObservedAt() {
+        // Given
+        Instant expected = Instant.now();
+        final VolumeUsage volumeUsage = new VolumeUsage("0", "/var/log/data", 1000, 1000, expected);
+        VolumeUsageResult result = VolumeUsageResult.success(List.of(volumeUsage));
+
+        // When
+        Instant actual = result.getObservedAt();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldSupplyMostRecentObservationTimestamp() {
+        // Given
+        Instant earlier = Instant.now().truncatedTo(ChronoUnit.DAYS);
+        Instant later = earlier.plus(1, ChronoUnit.DAYS);
+        final VolumeUsage volumeUsage = new VolumeUsage("0", "/var/log/data", 1000, 1000, earlier);
+        final VolumeUsage volumeUsage2 = new VolumeUsage("1", "/var/log/data", 1000, 1000, later);
+        VolumeUsageResult result = VolumeUsageResult.success(List.of(volumeUsage, volumeUsage2));
+
+        // When
+        Instant actual = result.getObservedAt();
+
+        // Then
+        assertThat(actual).isEqualTo(later);
+    }
+}

--- a/src/test/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottleTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottleTest.java
@@ -56,35 +56,35 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void testFallbackWhenFactorExpired() {
+    void testFallbackWhenFactorExpired() {
         givenFactorIsExpired();
         whenCheckForStaleFactor(policyBasedThrottle);
         thenFactorUpdatedToFallback(policyBasedThrottle);
     }
 
     @Test
-    public void testFallbackWhenFactorExpiredAndFailedVolumeUsageResult() {
+    void testFallbackWhenFactorExpiredAndFailedVolumeUsageResult() {
         givenFactorIsExpired();
         whenVolumeUsageResultFailureObserved();
         thenFactorUpdatedToFallback(policyBasedThrottle);
     }
 
     @Test
-    public void testCurrentFactorContinuesOnFailedVolumeUsageResult() {
+    void testCurrentFactorContinuesOnFailedVolumeUsageResult() {
         givenFactorIsCurrent();
         whenVolumeUsageResultFailureObserved();
         thenFactorUnchanged();
     }
 
     @Test
-    public void testCurrentFactorContinuesOnStalenessCheck() {
+    void testCurrentFactorContinuesOnStalenessCheck() {
         givenFactorIsCurrent();
         whenCheckForStaleFactor(policyBasedThrottle);
         thenFactorUnchanged();
     }
 
     @Test
-    public void testCurrentThrottleFactorValidFromUpdatedOnSuccessfulVolumeUsageResult() {
+    void testCurrentThrottleFactorValidFromUpdatedOnSuccessfulVolumeUsageResult() {
         Instant now = givenFixedTimeProgressedOneMinute();
         whenVolumeUsageResultSuccessObserved();
         thenCurrentThrottleFactorValidFrom(now);
@@ -115,7 +115,7 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void shouldNotIncrementFallbackFactorApplied() {
+    void shouldNotIncrementFallbackFactorApplied() {
         //Given
         givenFactorIsCurrent();
 
@@ -129,7 +129,7 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void shouldCountFallbackFactorApplied() {
+    void shouldCountFallbackFactorApplied() {
         //Given
         givenFactorIsExpired();
 
@@ -142,7 +142,7 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void shouldNotCountFallbackFactorAppliedWhenFactorIsValid() {
+    void shouldNotCountFallbackFactorAppliedWhenFactorIsValid() {
         //Given
         final FixedDurationExpiryPolicy oneMinuteExpiryPolicy = new FixedDurationExpiryPolicy(clock, Duration.ofMinutes(1L));
         policyBasedThrottle = new PolicyBasedThrottle(THROTTLE_FACTOR_POLICY, runnable, clock, oneMinuteExpiryPolicy, 0.0, defaultTags);
@@ -158,7 +158,7 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void shouldIncrementFallbackFactorAppliedWhenPreviousFactorExpires() {
+    void shouldIncrementFallbackFactorAppliedWhenPreviousFactorExpires() {
         //Given
         final FixedDurationExpiryPolicy thirtySecondExpiryPolicy = new FixedDurationExpiryPolicy(clock, Duration.ofSeconds(30L));
         policyBasedThrottle = new PolicyBasedThrottle(THROTTLE_FACTOR_POLICY, runnable, clock, thirtySecondExpiryPolicy, 0.0, defaultTags);
@@ -174,7 +174,7 @@ class PolicyBasedThrottleTest {
     }
 
     @Test
-    public void shouldIncrementFallbackFactorAppliedOnEachExpiry() {
+    void shouldIncrementFallbackFactorAppliedOnEachExpiry() {
         //Given
         final FixedDurationExpiryPolicy thirtySecondExpiryPolicy = new FixedDurationExpiryPolicy(clock, Duration.ofSeconds(30L));
         policyBasedThrottle = new PolicyBasedThrottle(THROTTLE_FACTOR_POLICY, runnable, clock, thirtySecondExpiryPolicy, 0.0, defaultTags);

--- a/src/test/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottleTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/throttle/PolicyBasedThrottleTest.java
@@ -209,7 +209,7 @@ class PolicyBasedThrottleTest {
     }
 
     private void whenVolumeUsageResultSuccessObserved() {
-        VolumeUsage arbitraryUsage = new VolumeUsage("1", "/tmp", 1000, 1000);
+        VolumeUsage arbitraryUsage = new VolumeUsage("1", "/tmp", 1000, 1000, Instant.now());
         policyBasedThrottle.observeVolumeUsage(VolumeUsageResult.success(List.of(arbitraryUsage)));
     }
 


### PR DESCRIPTION
This PR adds the notion of an observation time to the Volume Usage data and a `CachingVolumeObserver` which uses that to ensure we maintain valid observations for the configured validity duration. 

The caching is used to address issues where one set of brokers is returned by the describe cluster API call, however one of those brokers goes offline and is not included in the results of the describe logDirs API call.

This is a limited to solution as it relies on in memory state and thus there remain scenarios where re-starting a broker can lead to problematic throttling decisions. The additional overhead of maintaining shared state between plug-ins in the cluster combined with how unlikely this case is to occur suggests its not worth the effort of addressing that.

Fixes: #40 