### PR TITLE
Allow a storage check interval >0 along with no limit configuration

### DIFF
--- a/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
+++ b/src/test/java/io/strimzi/kafka/quotas/StaticQuotaCallbackTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -152,6 +153,21 @@ class StaticQuotaCallbackTest {
         //Then
         double quotaLimit = quotaCallback.quotaLimit(ClientQuotaType.PRODUCE, Map.of());
         assertThat(quotaLimit).isCloseTo(1.0, offset(0.00001d));
+    }
+
+    @Test
+    void configuringCheckIntervalWithNoVolumeLimitsDisablesStorageCheck() {
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        StaticQuotaCallback quotaCallback = new StaticQuotaCallback(volumeSourceBuilder, executor, Clock.systemUTC());
+
+        quotaCallback.configure(Map.of(
+                StaticQuotaConfig.STORAGE_CHECK_INTERVAL_PROP, "10",
+                StaticQuotaConfig.ADMIN_BOOTSTRAP_SERVER_PROP, "localhost:9092",
+                BROKER_ID_PROPERTY, BROKER_ID_PROPERTY
+        ));
+
+        verifyNoInteractions(volumeSourceBuilder);
+        verifyNoInteractions(executor);
     }
 
     @Test


### PR DESCRIPTION
Why:
This will enable us to set a default interval (see #47), which will help prevent configuration errors. In the absence of any limit configuration the storage check scheduled work will not be enabled, but the broker will start and can apply the static produce/fetch quotas.

Currently if you configure a non-zero check interval but do not provide a per-volume absolute bytes or ratio limit, then the plugin throws an exception during startup, which will prevent the broker from starting.