### PR TITLE
Fix pushing of artifacts to Nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
-export GPG_TTY=$(tty)
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
 
+# Run the cleanup on failure / exit
+trap cleanup EXIT
+
+export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
 GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,24 @@
             <organization>Red Hat</organization>
             <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
+        <developer>
+            <name>Paul Mellor</name>
+            <email>pmellor@redhat.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Lukáš Král</name>
+            <email>l.kral@outlook.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Maroš Orsák</name>
+            <email>maros.orsak159@gmail.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
     </developers>
 
     <properties>
@@ -90,7 +108,7 @@
         <checkstyle.version>9.2.1</checkstyle.version>
         <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
         <spotbugs.version>4.7.2</spotbugs.version>
-        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some changes at Sonatype broker the way we push the JAR artifacts to Sonatype Nexus. This PR fixes it by updating the Sonatype plugin. It also updates the script we use for it to make it fail in case of problems.

It also updates the list of maintainers in the `pom.xml` file.