### PR TITLE
Prevent spotbugs-annotations from transitively leaking as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <version>${spotbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This change removes the need for other projects that package this dependency (e.g. `strimzi/strimzi-kafka-operator`) to explicitly exclude the `spotbug-annotations` from `kafka-quotas-plugin` dependency in their poms.

`spotbugs-annotations` is a test-time dependency, but due to the mechanics of how it operates it is declared as compile time dependency which causes it to be automatically transitively pulled in when this project is referenced as a dependency of another project. By making it `provided` scoped it is still present at compile time so it can perform its function during testing but it will not automatically be pulled into the using projects as a transitive dependency.