### PR TITLE
Moved to Java 17

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -4,14 +4,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
-          image: 'Ubuntu-22.04'
-          jdk_version: '11'
-          main_build: 'true'
         'java-17':
           image: 'Ubuntu-22.04'
           jdk_version: '17'
-          main_build: 'false'
+          main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -1,12 +1,12 @@
 jobs:
   - job: 'deploy_java'
     displayName: 'Deploy artifacts'
-    # Strategy for the job => we deploy the artifacts only from Java 11
+    # Strategy for the job => we deploy the artifacts from Java 17
     strategy:
       matrix:
-        'java-11':
+        'java-17':
           image: 'Ubuntu-22.04'
-          jdk_version: '11'
+          jdk_version: '17'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -1,7 +1,7 @@
 # Step to configure JAVA on the agent
 parameters:
   - name: JDK_VERSION
-    default: '11'
+    default: '17'
 steps:
   - task: JavaToolInstaller@0
     inputs:

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.surefire.version>3.0.0-M7</maven.surefire.version>


### PR DESCRIPTION
This PR moves the quotas plugin to use Java 17 because Kafka is going to drop Java 8 and 11 (on the broker side) with the coming 4.0 version.

I tested the plugin locally with a Kafka 4.0 RC0 and on Kubernetes within a Kafka 3.9 image.